### PR TITLE
🐛 Update Workspace predicate logic

### DIFF
--- a/.changes/unreleased/BUG FIXES-460-20240805-123610.yaml
+++ b/.changes/unreleased/BUG FIXES-460-20240805-123610.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: '`Workspace`: Fix an issue where, in some circumstances, the controller cannot properly handle the deletion event.'
+time: 2024-08-05T12:36:10.268919+02:00
+custom:
+    PR: "460"

--- a/controllers/workspace_controller.go
+++ b/controllers/workspace_controller.go
@@ -71,6 +71,13 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return requeueAfter(requeueInterval)
 	}
 
+	// TODO:
+	// - Think about using the DeleteFunc predicate.
+	if w.instance.DeletionTimestamp != nil && !controllerutil.ContainsFinalizer(&w.instance, workspaceFinalizer) {
+		w.log.Info("Workspace Controller", "msg", "object marked as deleted without finalizer, no further action is required")
+		return doNotRequeue()
+	}
+
 	// Migration Validation
 	if controllerutil.ContainsFinalizer(&w.instance, workspaceFinalizerAlpha1) {
 		w.log.Error(err, "Migration", "msg", fmt.Sprintf("spec contains old finalizer %s", workspaceFinalizerAlpha1))


### PR DESCRIPTION
### Description

In the [originally reported issue](https://github.com/hashicorp/hcp-terraform-operator/issues/440), a third-party controller adds its finalizer to a newly created CR which leads to failure during reconciliation(please refer to the original issue for more details). [This](https://github.com/hashicorp/hcp-terraform-operator/pull/457) PR fixed this issue, however, during development, I found that deleted CR is also affected by a third-party finalizer being added. If CR is marked as deleted and has a third-party finalizer, the workspace will be removed but then it will be created again without the ability to remove it.

This PR updates predicates to filter out events that have a deletion timestamp (CR marked as deleted) and do not have the Workspace finalizer. In addition to that, a new condition was added to the Workspace reconciliation loop to filter out proceeded CRs.

_This PR mainly fixes the Workspace controller, however, the same issue can happen with other controllers. We need to revise predicate logic to make it more flexible, straightforward, and clean._

#### Tests

- [![E2E on HCP Terraform Operator](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/end-to-end-tfc.yaml/badge.svg?branch=update-predicates&event=workflow_dispatch)](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/end-to-end-tfc.yaml?query=branch:update-predicates)
- [![E2E on HCP Terraform Operator [Helm]](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/helm-end-to-end-tfc.yaml/badge.svg?branch=update-predicates&event=workflow_dispatch)](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/helm-end-to-end-tfc.yaml?query=branch:update-predicates)
- [![E2E on Terraform Enterprise](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/end-to-end-tfe.yaml/badge.svg?branch=update-predicates&event=workflow_dispatch)](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/end-to-end-tfe.yaml?query=branch:update-predicates)
- [![E2E on Terraform Enterprise [Helm]](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/helm-end-to-end-tfe.yaml/badge.svg?branch=update-predicates&event=workflow_dispatch)](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/helm-end-to-end-tfe.yaml?query=branch:update-predicates)

### Usage Example

<!---
Please provide a usage example if you have implemented a new feature.
--->

### References

- Fix: https://github.com/hashicorp/hcp-terraform-operator/issues/440
- Related PR: https://github.com/hashicorp/hcp-terraform-operator/pull/457

### Community Note
<!--- Please keep this note for the community --->
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
