### PR TITLE
🤖 Fix Notifications tests

### DIFF
--- a/controllers/workspace_controller_test.go
+++ b/controllers/workspace_controller_test.go
@@ -261,7 +261,12 @@ func deleteWorkspace(instance *appv1alpha2.Workspace) {
 	namespacedName := getNamespacedName(instance)
 
 	// Delete the Kubernetes workspace object
-	Expect(k8sClient.Delete(ctx, instance)).Should(Succeed())
+	Expect(k8sClient.Delete(ctx, instance)).To(
+		Or(
+			Succeed(),
+			WithTransform(errors.IsNotFound, BeTrue()),
+		),
+	)
 
 	// Wait until the controller finishes the reconciliation after the deletion of the object
 	Eventually(func() bool {


### PR DESCRIPTION
### Description

Fix Notifications tests.

#### Tests

- [![E2E on HCP Terraform Operator](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/end-to-end-tfc.yaml/badge.svg?branch=fix-notifications-test&event=workflow_dispatch)](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/end-to-end-tfc.yaml?query=branch:fix-notifications-test)
- [![E2E on HCP Terraform Operator [Helm]](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/helm-end-to-end-tfc.yaml/badge.svg?branch=fix-notifications-test&event=workflow_dispatch)](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/helm-end-to-end-tfc.yaml?query=branch:fix-notifications-test)
- [![E2E on Terraform Enterprise](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/end-to-end-tfe.yaml/badge.svg?branch=fix-notifications-test&event=workflow_dispatch)](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/end-to-end-tfe.yaml?query=branch:fix-notifications-test)
- [![E2E on Terraform Enterprise [Helm]](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/helm-end-to-end-tfe.yaml/badge.svg?branch=fix-notifications-test&event=workflow_dispatch)](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/helm-end-to-end-tfe.yaml?query=branch:fix-notifications-test)

### Usage Example

N/A.

### References

N/A.

### Community Note

* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
