### PR TITLE
🚀 Add deletion policy to Workspace controller

### DIFF
--- a/.changes/unreleased/BREAKING CHANGES-470-20240909-090348.yaml
+++ b/.changes/unreleased/BREAKING CHANGES-470-20240909-090348.yaml
@@ -1,0 +1,5 @@
+kind: BREAKING CHANGES
+body: '`Workspace`: The new field, `spec.deletionPolicy`, is set to `retain` by default, which changes the previous default controller behavior when resources are deleted. The previous behavior corresponded to the `force` deletion policy value. This change is considered safer in cases of accidental resource deletion, planned migration, or other scenarios involving the deletion of a custom resource.'
+time: 2024-09-09T09:03:48.837008+02:00
+custom:
+    PR: "470"

--- a/.changes/unreleased/FEATURES-470-20240909-085913.yaml
+++ b/.changes/unreleased/FEATURES-470-20240909-085913.yaml
@@ -1,0 +1,5 @@
+kind: FEATURES
+body: '`Workspace`: Add a new field, `spec.deletionPolicy`, that specifies the behavior of the custom resource and its associated workspace when the custom resource is deleted.'
+time: 2024-09-09T08:59:13.827281+02:00
+custom:
+    PR: "470"

--- a/.changes/unreleased/NOTES-470-20241017-085430.yaml
+++ b/.changes/unreleased/NOTES-470-20241017-085430.yaml
@@ -1,0 +1,5 @@
+kind: NOTES
+body: The `Workspace` CRD has been changed. Please follow the Helm chart instructions on how to upgrade it.
+time: 2024-10-17T08:54:30.601217+02:00
+custom:
+    PR: "470"

--- a/api/v1alpha2/workspace_types.go
+++ b/api/v1alpha2/workspace_types.go
@@ -332,10 +332,10 @@ type Tag string
 type DeletionPolicy string
 
 const (
-	DeletionPolicyPreserve DeletionPolicy = "preserve"
-	DeletionPolicySoft     DeletionPolicy = "soft"
-	DeletionPolicyDestroy  DeletionPolicy = "destroy"
-	DeletionPolicyForce    DeletionPolicy = "force"
+	DeletionPolicyRetain  DeletionPolicy = "retain"
+	DeletionPolicySoft    DeletionPolicy = "soft"
+	DeletionPolicyDestroy DeletionPolicy = "destroy"
+	DeletionPolicyForce   DeletionPolicy = "force"
 )
 
 // NotificationTrigger represents the different TFC notifications that can be sent as a run's progress transitions between different states.
@@ -442,11 +442,11 @@ type WorkspaceSpec struct {
 	//+optional
 	ApplyMethod string `json:"applyMethod,omitempty"`
 	// Allows a destroy plan to be created and applied.
-	// Default: `true`.
+	// Default: `false`.
 	// More information:
 	//   - https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings#destruction-and-deletion
 	//
-	//+kubebuilder:default=true
+	//+kubebuilder:default=false
 	//+optional
 	AllowDestroyPlan bool `json:"allowDestroyPlan"`
 	// Workspace description.
@@ -570,8 +570,15 @@ type WorkspaceSpec struct {
 	//
 	//+optional
 	Project *WorkspaceProject `json:"project,omitempty"`
-	//+kubebuilder:validation:Enum:=preserve;soft;destroy;force
-	//+kubebuilder:default=preserve
+	// The Deletion Policy specifies the behavior of the custom resource and its associated workspace when the custom resource is deleted.
+	// - `retain`: When the custom resource is deleted, the associated workspace is retained.
+	// - `soft`: Attempts to delete the associated workspace only if it does not contain any managed resources.
+	// - `destroy`: Executes a destroy operation to remove all resources managed by the associated workspace. Once the destruction of these resources is successful, the workspace itself is deleted, followed by the removal of the custom resource.
+	// - `force`: Forcefully and immediately deletes the workspace and the custom resource.
+	// Default: `retain`.
+	//
+	//+kubebuilder:validation:Enum:=retain;soft;destroy;force
+	//+kubebuilder:default=retain
 	//+optional
 	DeletionPolicy DeletionPolicy `json:"deletionPolicy,omitempty"`
 }

--- a/api/v1alpha2/workspace_types.go
+++ b/api/v1alpha2/workspace_types.go
@@ -451,11 +451,11 @@ type WorkspaceSpec struct {
 	//+optional
 	ApplyMethod string `json:"applyMethod,omitempty"`
 	// Allows a destroy plan to be created and applied.
-	// Default: `false`.
+	// Default: `true`.
 	// More information:
 	//   - https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings#destruction-and-deletion
 	//
-	//+kubebuilder:default=false
+	//+kubebuilder:default=true
 	//+optional
 	AllowDestroyPlan bool `json:"allowDestroyPlan"`
 	// Workspace description.

--- a/api/v1alpha2/workspace_types.go
+++ b/api/v1alpha2/workspace_types.go
@@ -329,6 +329,15 @@ type SSHKey struct {
 // +kubebuilder:validation:Pattern:="^[A-Za-z0-9][A-Za-z0-9:_-]*$"
 type Tag string
 
+type DeletionPolicy string
+
+const (
+	DeletionPolicyPreserve DeletionPolicy = "preserve"
+	DeletionPolicySoft     DeletionPolicy = "soft"
+	DeletionPolicyDestroy  DeletionPolicy = "destroy"
+	DeletionPolicyForce    DeletionPolicy = "force"
+)
+
 // NotificationTrigger represents the different TFC notifications that can be sent as a run's progress transitions between different states.
 // This must be aligned with go-tfe type `NotificationTriggerType`.
 // Must be one of the following values: `run:applying`, `assessment:check_failure`, `run:completed`, `run:created`, `assessment:drifted`, `run:errored`, `assessment:failed`, `run:needs_attention`, `run:planning`.
@@ -561,6 +570,10 @@ type WorkspaceSpec struct {
 	//
 	//+optional
 	Project *WorkspaceProject `json:"project,omitempty"`
+	//+kubebuilder:validation:Enum:=preserve;soft;destroy;force
+	//+kubebuilder:default=preserve
+	//+optional
+	DeletionPolicy DeletionPolicy `json:"deletionPolicy,omitempty"`
 }
 
 type PlanStatus struct {

--- a/api/v1alpha2/workspace_types.go
+++ b/api/v1alpha2/workspace_types.go
@@ -329,6 +329,15 @@ type SSHKey struct {
 // +kubebuilder:validation:Pattern:="^[A-Za-z0-9][A-Za-z0-9:_-]*$"
 type Tag string
 
+// DeletionPolicy defines the strategies for resource deletion in the Kubernetes operator.
+// It controls how the operator should handle the deletion of resources when triggered by
+// a user action or system event.
+//
+// There are four possible values:
+// - `retain`: When the custom resource is deleted, the associated workspace is retained.
+// - `soft`: Attempts to delete the associated workspace only if it does not contain any managed resources.
+// - `destroy`: Executes a destroy operation to remove all resources managed by the associated workspace. Once the destruction of these resources is successful, the workspace itself is deleted, followed by the removal of the custom resource.
+// - `force`: Forcefully and immediately deletes the workspace and the custom resource.
 type DeletionPolicy string
 
 const (

--- a/charts/hcp-terraform-operator/README.md
+++ b/charts/hcp-terraform-operator/README.md
@@ -84,6 +84,14 @@ For a more detailed explanation, please refer to the [FAQ](../../docs/faq.md#gen
 
 #### Upgrade recommendations
 
+  - `2.6.0` to `2.7.0`
+
+    - The `Workspace` CRD has been changed:
+
+      ```console
+      $ kubectl replace -f https://raw.githubusercontent.com/hashicorp/hcp-terraform-operator/v2.7.0/charts/hcp-terraform-operator/crds/app.terraform.io_workspaces.yaml
+      ```
+
   - `2.5.0` to `2.6.0`
 
     - The `AgentPool` CRD has been changed:

--- a/charts/hcp-terraform-operator/README.md.gotmpl
+++ b/charts/hcp-terraform-operator/README.md.gotmpl
@@ -84,6 +84,14 @@ For a more detailed explanation, please refer to the [FAQ](../../docs/faq.md#gen
 
 #### Upgrade recommendations
 
+  - `2.6.0` to `2.7.0`
+
+    - The `Workspace` CRD has been changed:
+
+      ```console
+      $ kubectl replace -f https://raw.githubusercontent.com/hashicorp/hcp-terraform-operator/v2.7.0/charts/hcp-terraform-operator/crds/app.terraform.io_workspaces.yaml
+      ```
+
   - `2.5.0` to `2.6.0`
 
     - The `AgentPool` CRD has been changed:
@@ -91,7 +99,6 @@ For a more detailed explanation, please refer to the [FAQ](../../docs/faq.md#gen
       ```console
       $ kubectl replace -f https://raw.githubusercontent.com/hashicorp/hcp-terraform-operator/v2.6.0/charts/hcp-terraform-operator/crds/app.terraform.io_agentpools.yaml
       ```
-
 
   - `2.3.0` to `2.4.0`
 

--- a/charts/hcp-terraform-operator/crds/app.terraform.io_workspaces.yaml
+++ b/charts/hcp-terraform-operator/crds/app.terraform.io_workspaces.yaml
@@ -81,6 +81,14 @@ spec:
                     - https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings#auto-apply-and-manual-apply
                 pattern: ^(auto|manual)$
                 type: string
+              deletionPolicy:
+                default: preserve
+                enum:
+                - preserve
+                - soft
+                - destroy
+                - force
+                type: string
               description:
                 description: Workspace description.
                 minLength: 1

--- a/charts/hcp-terraform-operator/crds/app.terraform.io_workspaces.yaml
+++ b/charts/hcp-terraform-operator/crds/app.terraform.io_workspaces.yaml
@@ -64,10 +64,10 @@ spec:
                     type: string
                 type: object
               allowDestroyPlan:
-                default: true
+                default: false
                 description: |-
                   Allows a destroy plan to be created and applied.
-                  Default: `true`.
+                  Default: `false`.
                   More information:
                     - https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings#destruction-and-deletion
                 type: boolean
@@ -82,9 +82,16 @@ spec:
                 pattern: ^(auto|manual)$
                 type: string
               deletionPolicy:
-                default: preserve
+                default: retain
+                description: |-
+                  The Deletion Policy specifies the behavior of the custom resource and its associated workspace when the custom resource is deleted.
+                  - `retain`: When the custom resource is deleted, the associated workspace is retained.
+                  - `soft`: Attempts to delete the associated workspace only if it does not contain any managed resources.
+                  - `destroy`: Executes a destroy operation to remove all resources managed by the associated workspace. Once the destruction of these resources is successful, the workspace itself is deleted, followed by the removal of the custom resource.
+                  - `force`: Forcefully and immediately deletes the workspace and the custom resource.
+                  Default: `retain`.
                 enum:
-                - preserve
+                - retain
                 - soft
                 - destroy
                 - force

--- a/charts/hcp-terraform-operator/crds/app.terraform.io_workspaces.yaml
+++ b/charts/hcp-terraform-operator/crds/app.terraform.io_workspaces.yaml
@@ -64,10 +64,10 @@ spec:
                     type: string
                 type: object
               allowDestroyPlan:
-                default: false
+                default: true
                 description: |-
                   Allows a destroy plan to be created and applied.
-                  Default: `false`.
+                  Default: `true`.
                   More information:
                     - https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings#destruction-and-deletion
                 type: boolean

--- a/config/crd/bases/app.terraform.io_workspaces.yaml
+++ b/config/crd/bases/app.terraform.io_workspaces.yaml
@@ -61,10 +61,10 @@ spec:
                     type: string
                 type: object
               allowDestroyPlan:
-                default: false
+                default: true
                 description: |-
                   Allows a destroy plan to be created and applied.
-                  Default: `false`.
+                  Default: `true`.
                   More information:
                     - https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings#destruction-and-deletion
                 type: boolean

--- a/config/crd/bases/app.terraform.io_workspaces.yaml
+++ b/config/crd/bases/app.terraform.io_workspaces.yaml
@@ -61,10 +61,10 @@ spec:
                     type: string
                 type: object
               allowDestroyPlan:
-                default: true
+                default: false
                 description: |-
                   Allows a destroy plan to be created and applied.
-                  Default: `true`.
+                  Default: `false`.
                   More information:
                     - https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings#destruction-and-deletion
                 type: boolean
@@ -79,9 +79,16 @@ spec:
                 pattern: ^(auto|manual)$
                 type: string
               deletionPolicy:
-                default: preserve
+                default: retain
+                description: |-
+                  The Deletion Policy specifies the behavior of the custom resource and its associated workspace when the custom resource is deleted.
+                  - `retain`: When the custom resource is deleted, the associated workspace is retained.
+                  - `soft`: Attempts to delete the associated workspace only if it does not contain any managed resources.
+                  - `destroy`: Executes a destroy operation to remove all resources managed by the associated workspace. Once the destruction of these resources is successful, the workspace itself is deleted, followed by the removal of the custom resource.
+                  - `force`: Forcefully and immediately deletes the workspace and the custom resource.
+                  Default: `retain`.
                 enum:
-                - preserve
+                - retain
                 - soft
                 - destroy
                 - force

--- a/config/crd/bases/app.terraform.io_workspaces.yaml
+++ b/config/crd/bases/app.terraform.io_workspaces.yaml
@@ -78,6 +78,14 @@ spec:
                     - https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings#auto-apply-and-manual-apply
                 pattern: ^(auto|manual)$
                 type: string
+              deletionPolicy:
+                default: preserve
+                enum:
+                - preserve
+                - soft
+                - destroy
+                - force
+                type: string
               description:
                 description: Workspace description.
                 minLength: 1

--- a/controllers/agentpool_controller.go
+++ b/controllers/agentpool_controller.go
@@ -166,8 +166,8 @@ func (r *AgentPoolReconciler) removeFinalizer(ctx context.Context, ap *agentPool
 
 	err := r.Update(ctx, &ap.instance)
 	if err != nil {
-		ap.log.Error(err, "Reconcile Agent Pool", "msg", fmt.Sprintf("failed to remove finazlier %s", agentPoolFinalizer))
-		r.Recorder.Eventf(&ap.instance, corev1.EventTypeWarning, "RemoveFinalizer", "Failed to remove finazlier %s", agentPoolFinalizer)
+		ap.log.Error(err, "Reconcile Agent Pool", "msg", fmt.Sprintf("failed to remove finalizer %s", agentPoolFinalizer))
+		r.Recorder.Eventf(&ap.instance, corev1.EventTypeWarning, "RemoveFinalizer", "Failed to remove finalizer %s", agentPoolFinalizer)
 	}
 
 	return err
@@ -214,7 +214,7 @@ func (r *AgentPoolReconciler) updateAgentPool(ctx context.Context, ap *agentPool
 
 func (r *AgentPoolReconciler) deleteAgentPool(ctx context.Context, ap *agentPoolInstance) error {
 	if ap.instance.Status.AgentPoolID == "" {
-		ap.log.Info("Reconcile Agent Pool", "msg", fmt.Sprintf("status.agentPoolID is empty, remove finazlier %s", agentPoolFinalizer))
+		ap.log.Info("Reconcile Agent Pool", "msg", fmt.Sprintf("status.agentPoolID is empty, remove finalizer %s", agentPoolFinalizer))
 		return r.removeFinalizer(ctx, ap)
 	}
 	err := ap.tfClient.Client.AgentPools.Delete(ctx, ap.instance.Status.AgentPoolID)
@@ -230,7 +230,7 @@ func (r *AgentPoolReconciler) deleteAgentPool(ctx context.Context, ap *agentPool
 		return err
 	}
 
-	ap.log.Info("Reconcile Agent Pool", "msg", fmt.Sprintf("agent pool ID %s has been deleted, remove finazlier", ap.instance.Status.AgentPoolID))
+	ap.log.Info("Reconcile Agent Pool", "msg", fmt.Sprintf("agent pool ID %s has been deleted, remove finalizer", ap.instance.Status.AgentPoolID))
 	return r.removeFinalizer(ctx, ap)
 }
 

--- a/controllers/module_controller.go
+++ b/controllers/module_controller.go
@@ -227,8 +227,8 @@ func (r *ModuleReconciler) removeFinalizer(ctx context.Context, m *moduleInstanc
 
 	err := r.Update(ctx, &m.instance)
 	if err != nil {
-		m.log.Error(err, "Reconcile Module", "msg", fmt.Sprintf("failed to remove finazlier %s", moduleFinalizer))
-		r.Recorder.Eventf(&m.instance, corev1.EventTypeWarning, "RemoveFinalizer", "Failed to remove finazlier %s", moduleFinalizer)
+		m.log.Error(err, "Reconcile Module", "msg", fmt.Sprintf("failed to remove finalizer %s", moduleFinalizer))
+		r.Recorder.Eventf(&m.instance, corev1.EventTypeWarning, "RemoveFinalizer", "Failed to remove finalizer %s", moduleFinalizer)
 	}
 
 	return err

--- a/controllers/project_controller.go
+++ b/controllers/project_controller.go
@@ -168,8 +168,8 @@ func (r *ProjectReconciler) removeFinalizer(ctx context.Context, p *projectInsta
 
 	err := r.Update(ctx, &p.instance)
 	if err != nil {
-		p.log.Error(err, "Reconcile Project", "msg", fmt.Sprintf("failed to remove finazlier %s", projectFinalizer))
-		r.Recorder.Eventf(&p.instance, corev1.EventTypeWarning, "RemoveProject", "Failed to remove finazlier %s", projectFinalizer)
+		p.log.Error(err, "Reconcile Project", "msg", fmt.Sprintf("failed to remove finalizer %s", projectFinalizer))
+		r.Recorder.Eventf(&p.instance, corev1.EventTypeWarning, "RemoveProject", "Failed to remove finalizer %s", projectFinalizer)
 	}
 
 	return err
@@ -228,7 +228,7 @@ func (r *ProjectReconciler) deleteProject(ctx context.Context, p *projectInstanc
 	// if the Kubernetes object doesn't have project ID, it means it a project was never created
 	// in this case, remove the finalizer and let Kubernetes remove the object permanently
 	if p.instance.Status.ID == "" {
-		p.log.Info("Reconcile Project", "msg", fmt.Sprintf("status.ID is empty, remove finazlier %s", projectFinalizer))
+		p.log.Info("Reconcile Project", "msg", fmt.Sprintf("status.ID is empty, remove finalizer %s", projectFinalizer))
 		return r.removeFinalizer(ctx, p)
 	}
 	err := p.tfClient.Client.Projects.Delete(ctx, p.instance.Status.ID)
@@ -236,7 +236,7 @@ func (r *ProjectReconciler) deleteProject(ctx context.Context, p *projectInstanc
 		// if project wasn't found, it means it was deleted from the TF Cloud bypass the operator
 		// in this case, remove the finalizer and let Kubernetes remove the object permanently
 		if err == tfc.ErrResourceNotFound {
-			p.log.Info("Reconcile Project", "msg", fmt.Sprintf("Project ID %s not found, remove finazlier", p.instance.Status.ID))
+			p.log.Info("Reconcile Project", "msg", fmt.Sprintf("Project ID %s not found, remove finalizer", p.instance.Status.ID))
 			return r.removeFinalizer(ctx, p)
 		}
 		p.log.Error(err, "Reconcile Project", "msg", fmt.Sprintf("failed to delete Project ID %s, retry later", projectFinalizer))
@@ -244,7 +244,7 @@ func (r *ProjectReconciler) deleteProject(ctx context.Context, p *projectInstanc
 		return err
 	}
 
-	p.log.Info("Reconcile Project", "msg", fmt.Sprintf("project ID %s has been deleted, remove finazlier", p.instance.Status.ID))
+	p.log.Info("Reconcile Project", "msg", fmt.Sprintf("project ID %s has been deleted, remove finalizer", p.instance.Status.ID))
 	return r.removeFinalizer(ctx, p)
 }
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -55,6 +55,7 @@ var cloudEndpoint = tfcDefaultAddress
 var syncPeriod = 30 * time.Second
 
 var secretKey = "token"
+var dummySecretKey = "dummy"
 var secretNamespacedName = types.NamespacedName{
 	Name:      "this",
 	Namespace: metav1.NamespaceDefault,
@@ -200,7 +201,8 @@ var _ = BeforeSuite(func() {
 		},
 		Type: corev1.SecretTypeOpaque,
 		Data: map[string][]byte{
-			secretKey: []byte(terraformToken),
+			secretKey:      []byte(terraformToken),
+			dummySecretKey: []byte(dummySecretKey),
 		},
 	})
 	Expect(err).ToNot(HaveOccurred(), "failed to create a token secret")

--- a/controllers/workspace_controller.go
+++ b/controllers/workspace_controller.go
@@ -428,30 +428,6 @@ func (r *WorkspaceReconciler) updateWorkspace(ctx context.Context, w *workspaceI
 	return w.tfClient.Client.Workspaces.UpdateByID(ctx, w.instance.Status.WorkspaceID, updateOptions)
 }
 
-func (r *WorkspaceReconciler) deleteWorkspace(ctx context.Context, w *workspaceInstance) error {
-	// if the Kubernetes object doesn't have workspace ID, it means it a workspace was never created
-	// in this case, remove the finalizer and let Kubernetes remove the object permanently
-	if w.instance.Status.WorkspaceID == "" {
-		w.log.Info("Reconcile Workspace", "msg", fmt.Sprintf("status.WorkspaceID is empty, remove finazlier %s", workspaceFinalizer))
-		return r.removeFinalizer(ctx, w)
-	}
-	err := w.tfClient.Client.Workspaces.DeleteByID(ctx, w.instance.Status.WorkspaceID)
-	if err != nil {
-		// if workspace wasn't found, it means it was deleted from the TF Cloud bypass the operator
-		// in this case, remove the finalizer and let Kubernetes remove the object permanently
-		if err == tfc.ErrResourceNotFound {
-			w.log.Info("Reconcile Workspace", "msg", fmt.Sprintf("Workspace ID %s not found, remove finazlier", workspaceFinalizer))
-			return r.removeFinalizer(ctx, w)
-		}
-		w.log.Error(err, "Reconcile Workspace", "msg", fmt.Sprintf("failed to delete Workspace ID %s, retry later", workspaceFinalizer))
-		r.Recorder.Eventf(&w.instance, corev1.EventTypeWarning, "ReconcileWorkspace", "Failed to delete Workspace ID %s, retry later", w.instance.Status.WorkspaceID)
-		return err
-	}
-
-	w.log.Info("Reconcile Workspace", "msg", fmt.Sprintf("workspace ID %s has been deleted, remove finazlier", w.instance.Status.WorkspaceID))
-	return r.removeFinalizer(ctx, w)
-}
-
 func (r *WorkspaceReconciler) reconcileWorkspace(ctx context.Context, w *workspaceInstance) error {
 	w.log.Info("Reconcile Workspace", "msg", "reconciling workspace")
 

--- a/controllers/workspace_controller.go
+++ b/controllers/workspace_controller.go
@@ -227,8 +227,8 @@ func (r *WorkspaceReconciler) removeFinalizer(ctx context.Context, w *workspaceI
 
 	err := r.Update(ctx, &w.instance)
 	if err != nil {
-		w.log.Error(err, "Reconcile Workspace", "msg", fmt.Sprintf("failed to remove finazlier %s", workspaceFinalizer))
-		r.Recorder.Eventf(&w.instance, corev1.EventTypeWarning, "RemoveFinalizer", "Failed to remove finazlier %s", workspaceFinalizer)
+		w.log.Error(err, "Reconcile Workspace", "msg", fmt.Sprintf("failed to remove finalizer %s", workspaceFinalizer))
+		r.Recorder.Eventf(&w.instance, corev1.EventTypeWarning, "RemoveFinalizer", "Failed to remove finalizer %s", workspaceFinalizer)
 	}
 
 	return err

--- a/controllers/workspace_controller_deletion_policy.go
+++ b/controllers/workspace_controller_deletion_policy.go
@@ -22,7 +22,7 @@ func (r *WorkspaceReconciler) deleteWorkspace(ctx context.Context, w *workspaceI
 	}
 
 	switch w.instance.Spec.DeletionPolicy {
-	case appv1alpha2.DeletionPolicyPreserve:
+	case appv1alpha2.DeletionPolicyRetain:
 		w.log.Info("Reconcile Workspace", "msg", fmt.Sprintf("remove finazlier %s", workspaceFinalizer))
 		return r.removeFinalizer(ctx, w)
 	case appv1alpha2.DeletionPolicySoft:

--- a/controllers/workspace_controller_deletion_policy.go
+++ b/controllers/workspace_controller_deletion_policy.go
@@ -17,19 +17,19 @@ func (r *WorkspaceReconciler) deleteWorkspace(ctx context.Context, w *workspaceI
 	w.log.Info("Reconcile Workspace", "msg", fmt.Sprintf("deletion policy is %s", w.instance.Spec.DeletionPolicy))
 
 	if w.instance.Status.WorkspaceID == "" {
-		w.log.Info("Reconcile Workspace", "msg", fmt.Sprintf("status.WorkspaceID is empty, remove finazlier %s", workspaceFinalizer))
+		w.log.Info("Reconcile Workspace", "msg", fmt.Sprintf("status.WorkspaceID is empty, remove finalizer %s", workspaceFinalizer))
 		return r.removeFinalizer(ctx, w)
 	}
 
 	switch w.instance.Spec.DeletionPolicy {
 	case appv1alpha2.DeletionPolicyRetain:
-		w.log.Info("Reconcile Workspace", "msg", fmt.Sprintf("remove finazlier %s", workspaceFinalizer))
+		w.log.Info("Reconcile Workspace", "msg", fmt.Sprintf("remove finalizer %s", workspaceFinalizer))
 		return r.removeFinalizer(ctx, w)
 	case appv1alpha2.DeletionPolicySoft:
 		err := w.tfClient.Client.Workspaces.SafeDeleteByID(ctx, w.instance.Status.WorkspaceID)
 		if err != nil {
 			if err == tfc.ErrResourceNotFound {
-				w.log.Info("Reconcile Workspace", "msg", "Workspace was not found, remove finazlier")
+				w.log.Info("Reconcile Workspace", "msg", "Workspace was not found, remove finalizer")
 				return r.removeFinalizer(ctx, w)
 			}
 			if err == tfc.ErrWorkspaceNotSafeToDelete {
@@ -40,16 +40,16 @@ func (r *WorkspaceReconciler) deleteWorkspace(ctx context.Context, w *workspaceI
 			r.Recorder.Eventf(&w.instance, corev1.EventTypeWarning, "ReconcileWorkspace", "Failed to safe delete Workspace ID %s, retry later", w.instance.Status.WorkspaceID)
 			return err
 		}
-		w.log.Info("Reconcile Workspace", "msg", fmt.Sprintf("workspace ID %s has been deleted, remove finazlier", w.instance.Status.WorkspaceID))
+		w.log.Info("Reconcile Workspace", "msg", fmt.Sprintf("workspace ID %s has been deleted, remove finalizer", w.instance.Status.WorkspaceID))
 		return r.removeFinalizer(ctx, w)
 	case appv1alpha2.DeletionPolicyDestroy:
-		// Not yet implemented
+		// TODO: Implement the destroy logic
 		return nil
 	case appv1alpha2.DeletionPolicyForce:
 		err := w.tfClient.Client.Workspaces.DeleteByID(ctx, w.instance.Status.WorkspaceID)
 		if err != nil {
 			if err == tfc.ErrResourceNotFound {
-				w.log.Info("Reconcile Workspace", "msg", "Workspace was not found, remove finazlier")
+				w.log.Info("Reconcile Workspace", "msg", "Workspace was not found, remove finalizer")
 				return r.removeFinalizer(ctx, w)
 			}
 			w.log.Error(err, "Reconcile Workspace", "msg", fmt.Sprintf("failed to force delete Workspace ID %s, retry later", w.instance.Status.WorkspaceID))
@@ -57,7 +57,7 @@ func (r *WorkspaceReconciler) deleteWorkspace(ctx context.Context, w *workspaceI
 			return err
 		}
 
-		w.log.Info("Reconcile Workspace", "msg", fmt.Sprintf("workspace ID %s has been deleted, remove finazlier", w.instance.Status.WorkspaceID))
+		w.log.Info("Reconcile Workspace", "msg", fmt.Sprintf("workspace ID %s has been deleted, remove finalizer", w.instance.Status.WorkspaceID))
 		return r.removeFinalizer(ctx, w)
 	}
 

--- a/controllers/workspace_controller_deletion_policy.go
+++ b/controllers/workspace_controller_deletion_policy.go
@@ -1,0 +1,65 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+
+	tfc "github.com/hashicorp/go-tfe"
+	corev1 "k8s.io/api/core/v1"
+
+	appv1alpha2 "github.com/hashicorp/hcp-terraform-operator/api/v1alpha2"
+)
+
+func (r *WorkspaceReconciler) deleteWorkspace(ctx context.Context, w *workspaceInstance) error {
+	w.log.Info("Reconcile Workspace", "msg", fmt.Sprintf("deletion policy is %s", w.instance.Spec.DeletionPolicy))
+
+	if w.instance.Status.WorkspaceID == "" {
+		w.log.Info("Reconcile Workspace", "msg", fmt.Sprintf("status.WorkspaceID is empty, remove finazlier %s", workspaceFinalizer))
+		return r.removeFinalizer(ctx, w)
+	}
+
+	switch w.instance.Spec.DeletionPolicy {
+	case appv1alpha2.DeletionPolicyPreserve:
+		w.log.Info("Reconcile Workspace", "msg", fmt.Sprintf("remove finazlier %s", workspaceFinalizer))
+		return r.removeFinalizer(ctx, w)
+	case appv1alpha2.DeletionPolicySoft:
+		err := w.tfClient.Client.Workspaces.SafeDeleteByID(ctx, w.instance.Status.WorkspaceID)
+		if err != nil {
+			if err == tfc.ErrResourceNotFound {
+				w.log.Info("Reconcile Workspace", "msg", "Workspace was not found, remove finazlier")
+				return r.removeFinalizer(ctx, w)
+			}
+			if err == tfc.ErrWorkspaceNotSafeToDelete {
+				w.log.Info("Reconcile Workspace", "msg", fmt.Sprintf("Workspace ID %s is still managing resources, retry later", w.instance.Status.WorkspaceID))
+				return nil
+			}
+			w.log.Error(err, "Reconcile Workspace", "msg", fmt.Sprintf("failed to soft delete Workspace ID %s, retry later", w.instance.Status.WorkspaceID))
+			r.Recorder.Eventf(&w.instance, corev1.EventTypeWarning, "ReconcileWorkspace", "Failed to safe delete Workspace ID %s, retry later", w.instance.Status.WorkspaceID)
+			return err
+		}
+		w.log.Info("Reconcile Workspace", "msg", fmt.Sprintf("workspace ID %s has been deleted, remove finazlier", w.instance.Status.WorkspaceID))
+		return r.removeFinalizer(ctx, w)
+	case appv1alpha2.DeletionPolicyDestroy:
+		// Not yet implemented
+		return nil
+	case appv1alpha2.DeletionPolicyForce:
+		err := w.tfClient.Client.Workspaces.DeleteByID(ctx, w.instance.Status.WorkspaceID)
+		if err != nil {
+			if err == tfc.ErrResourceNotFound {
+				w.log.Info("Reconcile Workspace", "msg", "Workspace was not found, remove finazlier")
+				return r.removeFinalizer(ctx, w)
+			}
+			w.log.Error(err, "Reconcile Workspace", "msg", fmt.Sprintf("failed to force delete Workspace ID %s, retry later", w.instance.Status.WorkspaceID))
+			r.Recorder.Eventf(&w.instance, corev1.EventTypeWarning, "ReconcileWorkspace", "Failed to force delete Workspace ID %s, retry later", w.instance.Status.WorkspaceID)
+			return err
+		}
+
+		w.log.Info("Reconcile Workspace", "msg", fmt.Sprintf("workspace ID %s has been deleted, remove finazlier", w.instance.Status.WorkspaceID))
+		return r.removeFinalizer(ctx, w)
+	}
+
+	return nil
+}

--- a/controllers/workspace_controller_deletion_policy_test.go
+++ b/controllers/workspace_controller_deletion_policy_test.go
@@ -1,0 +1,151 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package controllers
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	tfc "github.com/hashicorp/go-tfe"
+	appv1alpha2 "github.com/hashicorp/hcp-terraform-operator/api/v1alpha2"
+)
+
+var _ = Describe("Workspace controller", Ordered, func() {
+	var (
+		instance       *appv1alpha2.Workspace
+		namespacedName types.NamespacedName
+		workspace      string
+	)
+
+	BeforeAll(func() {
+		// Set default Eventually timers
+		SetDefaultEventuallyTimeout(syncPeriod * 4)
+		SetDefaultEventuallyPollingInterval(2 * time.Second)
+	})
+
+	BeforeEach(func() {
+		namespacedName = newNamespacedName()
+		workspace = fmt.Sprintf("kubernetes-operator-%v", randomNumber())
+		// Create a new workspace object for each test
+		instance = &appv1alpha2.Workspace{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "app.terraform.io/v1alpha2",
+				Kind:       "Workspace",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              namespacedName.Name,
+				Namespace:         namespacedName.Namespace,
+				DeletionTimestamp: nil,
+				Finalizers:        []string{},
+			},
+			Spec: appv1alpha2.WorkspaceSpec{
+				Organization: organization,
+				Token: appv1alpha2.Token{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: secretNamespacedName.Name,
+						},
+						Key: secretKey,
+					},
+				},
+				Name:        workspace,
+				ApplyMethod: "auto",
+			},
+			Status: appv1alpha2.WorkspaceStatus{},
+		}
+	})
+
+	AfterEach(func() {
+		deleteWorkspace(instance)
+	})
+
+	Context("Deletion Policy", func() {
+		It("can delete a resource that does not manage a workspace", func() {
+			instance.Spec.Token.SecretKeyRef.Key = dummySecretKey
+			Expect(k8sClient.Create(ctx, instance)).Should(Succeed())
+		})
+		It("can preserve a workspace", func() {
+			instance.Spec.DeletionPolicy = appv1alpha2.DeletionPolicyPreserve
+			createWorkspace(instance)
+			workspaceID := instance.Status.WorkspaceID
+			Expect(k8sClient.Delete(ctx, instance)).To(Succeed())
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, namespacedName, instance)
+				return errors.IsNotFound(err)
+			}).Should(BeTrue())
+			workspace, err := tfClient.Workspaces.ReadByID(ctx, workspaceID)
+			Expect(err).Should(Succeed())
+			Expect(workspace).NotTo(BeNil())
+		})
+		It("can soft delete a workspace", func() {
+			instance.Spec.AllowDestroyPlan = true
+			instance.Spec.DeletionPolicy = appv1alpha2.DeletionPolicySoft
+			createWorkspace(instance)
+			workspaceID := instance.Status.WorkspaceID
+
+			cv := createAndUploadConfigurationVersion(instance, "hoi")
+			Eventually(func() bool {
+				listOpts := tfc.ListOptions{
+					PageNumber: 1,
+					PageSize:   maxPageSize,
+				}
+				for listOpts.PageNumber != 0 {
+					runs, err := tfClient.Runs.List(ctx, workspaceID, &tfc.RunListOptions{
+						ListOptions: listOpts,
+					})
+					Expect(err).To(Succeed())
+					for _, r := range runs.Items {
+						if r.ConfigurationVersion.ID == cv.ID {
+							return r.Status == tfc.RunApplied
+						}
+					}
+					listOpts.PageNumber = runs.NextPage
+				}
+				return false
+			}).Should(BeTrue())
+
+			Expect(k8sClient.Delete(ctx, instance)).To(Succeed())
+
+			run, err := tfClient.Runs.Create(ctx, tfc.RunCreateOptions{
+				IsDestroy: tfc.Bool(true),
+				Workspace: &tfc.Workspace{
+					ID: workspaceID,
+				},
+				AutoApply: tfc.Bool(true),
+			})
+			Expect(err).To(Succeed())
+			Expect(run).ToNot(BeNil())
+
+			Eventually(func() bool {
+				_, err := tfClient.Workspaces.ReadByID(ctx, workspaceID)
+				return err == tfc.ErrResourceNotFound
+			}).Should(BeTrue())
+		})
+		It("can destroy delete a workspace", func() {
+			// Not yet implemented
+			instance.Spec.DeletionPolicy = appv1alpha2.DeletionPolicyDestroy
+		})
+		It("can force delete a workspace", func() {
+			instance.Spec.DeletionPolicy = appv1alpha2.DeletionPolicyForce
+			createWorkspace(instance)
+			workspaceID := instance.Status.WorkspaceID
+			Expect(k8sClient.Delete(ctx, instance)).To(Succeed())
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, namespacedName, instance)
+				return errors.IsNotFound(err)
+			}).Should(BeTrue())
+			workspace, err := tfClient.Workspaces.ReadByID(ctx, workspaceID)
+			Expect(err).To(MatchError(tfc.ErrResourceNotFound))
+			Expect(workspace).To(BeNil())
+		})
+	})
+})

--- a/controllers/workspace_controller_deletion_policy_test.go
+++ b/controllers/workspace_controller_deletion_policy_test.go
@@ -56,8 +56,11 @@ var _ = Describe("Workspace controller", Ordered, func() {
 						Key: secretKey,
 					},
 				},
-				Name:        workspace,
-				ApplyMethod: "auto",
+				Name:             workspace,
+				ApplyMethod:      "auto",
+				AllowDestroyPlan: false,
+				Description:      "Deletion Policy",
+				ExecutionMode:    "remote",
 			},
 			Status: appv1alpha2.WorkspaceStatus{},
 		}
@@ -86,6 +89,9 @@ var _ = Describe("Workspace controller", Ordered, func() {
 			Expect(workspace).NotTo(BeNil())
 		})
 		It("can soft delete a workspace", func() {
+			if cloudEndpoint != tfcDefaultAddress {
+				Skip("Does not run against TFC, skip this test")
+			}
 			instance.Spec.AllowDestroyPlan = true
 			instance.Spec.DeletionPolicy = appv1alpha2.DeletionPolicySoft
 			createWorkspace(instance)

--- a/controllers/workspace_controller_deletion_policy_test.go
+++ b/controllers/workspace_controller_deletion_policy_test.go
@@ -7,15 +7,14 @@ import (
 	"fmt"
 	"time"
 
+	tfc "github.com/hashicorp/go-tfe"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	tfc "github.com/hashicorp/go-tfe"
 	appv1alpha2 "github.com/hashicorp/hcp-terraform-operator/api/v1alpha2"
 )
 
@@ -73,8 +72,8 @@ var _ = Describe("Workspace controller", Ordered, func() {
 			instance.Spec.Token.SecretKeyRef.Key = dummySecretKey
 			Expect(k8sClient.Create(ctx, instance)).Should(Succeed())
 		})
-		It("can preserve a workspace", func() {
-			instance.Spec.DeletionPolicy = appv1alpha2.DeletionPolicyPreserve
+		It("can retain a workspace", func() {
+			instance.Spec.DeletionPolicy = appv1alpha2.DeletionPolicyRetain
 			createWorkspace(instance)
 			workspaceID := instance.Status.WorkspaceID
 			Expect(k8sClient.Delete(ctx, instance)).To(Succeed())

--- a/controllers/workspace_controller_outputs_test.go
+++ b/controllers/workspace_controller_outputs_test.go
@@ -167,7 +167,6 @@ func createAndUploadConfigurationVersion(instance *appv1alpha2.Workspace, output
 
 	Expect(tfClient.ConfigurationVersions.Upload(ctx, cv.UploadURL, td)).Should(Succeed())
 
-	By("Validating configuration version successful upload")
 	Eventually(func() bool {
 		c, err := tfClient.ConfigurationVersions.Read(ctx, cv.ID)
 		if err != nil {

--- a/controllers/workspace_controller_outputs_test.go
+++ b/controllers/workspace_controller_outputs_test.go
@@ -147,13 +147,14 @@ func createAndUploadConfigurationVersion(instance *appv1alpha2.Workspace, output
 	defer os.Remove(f.Name())
 	// Terraform code to upload
 	tf := fmt.Sprintf(`
+				resource "random_uuid" "this" {}
 				output "sensitive" {
-					value = "%s"
+					value = %[1]q
 					sensitive = true
 				}
 				output "non_sensitive" {
-					value = "%s"
-				}`, outputValue, outputValue)
+					value = %[1]q
+				}`, outputValue)
 	// Save the Terraform code to the temporary file
 	_, err = f.WriteString(tf)
 	Expect(err).Should(Succeed())

--- a/controllers/workspace_controller_outputs_test.go
+++ b/controllers/workspace_controller_outputs_test.go
@@ -8,14 +8,13 @@ import (
 	"os"
 	"time"
 
+	tfc "github.com/hashicorp/go-tfe"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	tfc "github.com/hashicorp/go-tfe"
 	appv1alpha2 "github.com/hashicorp/hcp-terraform-operator/api/v1alpha2"
 )
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -228,7 +228,16 @@ _Appears in:_
 
 _Underlying type:_ _string_
 
+DeletionPolicy defines the strategies for resource deletion in the Kubernetes operator.
+It controls how the operator should handle the deletion of resources when triggered by
+a user action or system event.
 
+
+There are four possible values:
+- `retain`: When the custom resource is deleted, the associated workspace is retained.
+- `soft`: Attempts to delete the associated workspace only if it does not contain any managed resources.
+- `destroy`: Executes a destroy operation to remove all resources managed by the associated workspace. Once the destruction of these resources is successful, the workspace itself is deleted, followed by the removal of the custom resource.
+- `force`: Forcefully and immediately deletes the workspace and the custom resource.
 
 _Appears in:_
 - [WorkspaceSpec](#workspacespec)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -224,6 +224,17 @@ _Appears in:_
 | `variables` _[WorkspaceVariablesPermissionType](#workspacevariablespermissiontype)_ | Variable access.<br />Must be one of the following values: `none`, `read`, `write`.<br />Default: `none`. |
 
 
+#### DeletionPolicy
+
+_Underlying type:_ _string_
+
+
+
+_Appears in:_
+- [WorkspaceSpec](#workspacespec)
+
+
+
 #### Module
 
 
@@ -802,6 +813,7 @@ _Appears in:_
 | `sshKey` _[SSHKey](#sshkey)_ | SSH key used to clone Terraform modules.<br />More information:<br />  - https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings/ssh-keys |
 | `notifications` _[Notification](#notification) array_ | Notifications allow you to send messages to other applications based on run and workspace events.<br />More information:<br />  - https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings/notifications |
 | `project` _[WorkspaceProject](#workspaceproject)_ | Projects let you organize your workspaces into groups.<br />Default: default organization project.<br />More information:<br />  - https://developer.hashicorp.com/terraform/tutorials/cloud/projects |
+| `deletionPolicy` _[DeletionPolicy](#deletionpolicy)_ |  |
 
 
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -796,7 +796,7 @@ _Appears in:_
 | `organization` _string_ | Organization name where the Workspace will be created.<br />More information:<br />  - https://developer.hashicorp.com/terraform/cloud-docs/users-teams-organizations/organizations |
 | `token` _[Token](#token)_ | API Token to be used for API calls. |
 | `applyMethod` _string_ | Define either change will be applied automatically(auto) or require an operator to confirm(manual).<br />Must be one of the following values: `auto`, `manual`.<br />Default: `manual`.<br />More information:<br />  - https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings#auto-apply-and-manual-apply |
-| `allowDestroyPlan` _boolean_ | Allows a destroy plan to be created and applied.<br />Default: `true`.<br />More information:<br />  - https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings#destruction-and-deletion |
+| `allowDestroyPlan` _boolean_ | Allows a destroy plan to be created and applied.<br />Default: `false`.<br />More information:<br />  - https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings#destruction-and-deletion |
 | `description` _string_ | Workspace description. |
 | `agentPool` _[WorkspaceAgentPool](#workspaceagentpool)_ | HCP Terraform Agents allow HCP Terraform to communicate with isolated, private, or on-premises infrastructure.<br />More information:<br />  - https://developer.hashicorp.com/terraform/cloud-docs/agents |
 | `executionMode` _string_ | Define where the Terraform code will be executed.<br />Must be one of the following values: `agent`, `local`, `remote`.<br />Default: `remote`.<br />More information:<br />  - https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings#execution-mode |
@@ -813,7 +813,7 @@ _Appears in:_
 | `sshKey` _[SSHKey](#sshkey)_ | SSH key used to clone Terraform modules.<br />More information:<br />  - https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings/ssh-keys |
 | `notifications` _[Notification](#notification) array_ | Notifications allow you to send messages to other applications based on run and workspace events.<br />More information:<br />  - https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings/notifications |
 | `project` _[WorkspaceProject](#workspaceproject)_ | Projects let you organize your workspaces into groups.<br />Default: default organization project.<br />More information:<br />  - https://developer.hashicorp.com/terraform/tutorials/cloud/projects |
-| `deletionPolicy` _[DeletionPolicy](#deletionpolicy)_ |  |
+| `deletionPolicy` _[DeletionPolicy](#deletionpolicy)_ | The Deletion Policy specifies the behavior of the custom resource and its associated workspace when the custom resource is deleted.<br />- `retain`: When the custom resource is deleted, the associated workspace is retained.<br />- `soft`: Attempts to delete the associated workspace only if it does not contain any managed resources.<br />- `destroy`: Executes a destroy operation to remove all resources managed by the associated workspace. Once the destruction of these resources is successful, the workspace itself is deleted, followed by the removal of the custom resource.<br />- `force`: Forcefully and immediately deletes the workspace and the custom resource.<br />Default: `retain`. |
 
 
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -805,7 +805,7 @@ _Appears in:_
 | `organization` _string_ | Organization name where the Workspace will be created.<br />More information:<br />  - https://developer.hashicorp.com/terraform/cloud-docs/users-teams-organizations/organizations |
 | `token` _[Token](#token)_ | API Token to be used for API calls. |
 | `applyMethod` _string_ | Define either change will be applied automatically(auto) or require an operator to confirm(manual).<br />Must be one of the following values: `auto`, `manual`.<br />Default: `manual`.<br />More information:<br />  - https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings#auto-apply-and-manual-apply |
-| `allowDestroyPlan` _boolean_ | Allows a destroy plan to be created and applied.<br />Default: `false`.<br />More information:<br />  - https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings#destruction-and-deletion |
+| `allowDestroyPlan` _boolean_ | Allows a destroy plan to be created and applied.<br />Default: `true`.<br />More information:<br />  - https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings#destruction-and-deletion |
 | `description` _string_ | Workspace description. |
 | `agentPool` _[WorkspaceAgentPool](#workspaceagentpool)_ | HCP Terraform Agents allow HCP Terraform to communicate with isolated, private, or on-premises infrastructure.<br />More information:<br />  - https://developer.hashicorp.com/terraform/cloud-docs/agents |
 | `executionMode` _string_ | Define where the Terraform code will be executed.<br />Must be one of the following values: `agent`, `local`, `remote`.<br />Default: `remote`.<br />More information:<br />  - https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings#execution-mode |

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -263,7 +263,7 @@
 
   You might consider "disabling" the operator on the source cluster during migration. To do this, set the number of replicas to `0`.
 
-  Here are steps to migrate a workspace CR from one cluster to another:
+  This is an example of a workspace CR migration procedure from one cluster to another. *We highly recommend testing it in a non-production environment first and adjusting the steps according to your organization's policies and procedures before applying them in production.*
 
   - **Backup the existing workspace CR.** Export the workspace CR to a YAML file from the source cluster:
 
@@ -274,8 +274,7 @@
   - **Remove metadata fields.** You need to delete specific fields like `metadata.resourceVersion` and `metadata.uid` to avoid conflicts in the target cluster. These fields are specific to the Kubernetes resource lifecycle in a given cluster:
 
     ```console
-    $ yq eval 'del(.metadata.resourceVersion)' -i backup.<NAME>.workspace.yaml
-    $ yq eval 'del(.metadata.uid)' -i backup.<NAME>.workspace.yaml
+    $ yq -i 'del(.metadata.creationTimestamp, .metadata.finalizers, .metadata.generation, .metadata.resourceVersion, .metadata.uid)' backup.<NAME>.workspace.yaml
     ```
 
   - **Apply the backup file to the target cluster.** Ensure that the operator is up and running on the target cluster. Apply the backed-up Workspace YAML to the target cluster:

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -263,7 +263,7 @@
 
   You might consider "disabling" the operator on the source cluster during migration. To do this, set the number of replicas to `0`.
 
-  Here are steps to migrsate a workspace CR from one cluster to another:
+  Here are steps to migrate a workspace CR from one cluster to another:
 
   - **Backup the existing workspace CR.** Export the workspace CR to a YAML file from the source cluster:
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -257,7 +257,7 @@
 
 - **How can I migrate workspace CR to a different cluster?**
 
-  Ensure that the `spec.deletionPolicy` of the workspace CR you are migrating is set to `retain`. This way, when you remove the workspace CR from the Kubernetes cluster, the operator will not delete the managed HCP Terraform workspace.
+  Ensure that the `spec.deletionPolicy` of the workspace CR you are migrating is set to `retain`. This way, when you remove the workspace CR from the Kubernetes cluster, the operator will not delete the managed HCP Terraform workspace. Note that `spec.deletionPolicy` has been available since version 2.7.0 and onward.
 
   We do not recommend having two or more installations of the operator managing the same HCP Terraform workspace to avoid conflicts. Please ensure that you remove the workspace CR from the source cluster once the migration is complete.
 


### PR DESCRIPTION
### Description

This PR adds a new field `spec.deletionPolicy` to the workspace schema.

`deletionPolicy` defines the strategies for resource deletion in the Kubernetes operator. It controls how the operator should handle the deletion of resources when triggered by a user action or system event.

There are four possible values:
  - `retain`: When the custom resource is deleted, the associated workspace is retained.
  - `soft`: Attempts to delete the associated workspace only if it does not contain any managed resources.
  - `destroy`: Executes a destroy operation to remove all resources managed by the associated workspace. Once the destruction of these resources is successful, the workspace itself is deleted, followed by the removal of the custom resource.
  - `force`: Forcefully and immediately deletes the workspace and the custom resource.

⚠️ The default `deletionPolicy` value is set to `retain`, as it is the safest option. However, the current behavior is equivalent to `force`. This decision was made intentionally to enhance the user experience.

❗ This PR does not implement a `destroy` policy as it requires more changes and will be implemented in a separate [PR](https://github.com/hashicorp/hcp-terraform-operator/pull/489).

#### Tests

- [![E2E on HCP Terraform Operator](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/end-to-end-tfc.yaml/badge.svg?branch=add-deletion-policy&event=workflow_dispatch)](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/end-to-end-tfc.yaml?query=branch:add-deletion-policy)
- [![E2E on HCP Terraform Operator [Helm]](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/helm-end-to-end-tfc.yaml/badge.svg?branch=add-deletion-policy&event=workflow_dispatch)](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/helm-end-to-end-tfc.yaml?query=branch:add-deletion-policy)
- [![E2E on Terraform Enterprise](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/end-to-end-tfe.yaml/badge.svg?branch=add-deletion-policy&event=workflow_dispatch)](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/end-to-end-tfe.yaml?query=branch:add-deletion-policy)
- [![E2E on Terraform Enterprise [Helm]](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/helm-end-to-end-tfe.yaml/badge.svg?branch=add-deletion-policy&event=workflow_dispatch)](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/helm-end-to-end-tfe.yaml?query=branch:add-deletion-policy)

### Usage Example

```yaml
---
apiVersion: app.terraform.io/v1alpha2
kind: Workspace
metadata:
  name: this
spec:
  organization: kubernetes-operator
  token:
    secretKeyRef:
      name: tfc-operator
      key: token
  name: this
  deletionPolicy: retain
```

### References

- Close: https://github.com/hashicorp/hcp-terraform-operator/issues/213

### Community Note

* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
