### PR TITLE
🚀 Add `--project-sync-period` CLI option

### DIFF
--- a/.changes/unreleased/FEATURES-479-20240830-090526.yaml
+++ b/.changes/unreleased/FEATURES-479-20240830-090526.yaml
@@ -1,0 +1,5 @@
+kind: FEATURES
+body: '`Helm`: Add a new value called `controllers.project.syncPeriod` to set the CLI option `--project-sync-period`.'
+time: 2024-08-30T09:05:26.954037+02:00
+custom:
+    PR: "479"

--- a/.changes/unreleased/FEATURES-479-20240830-090626.yaml
+++ b/.changes/unreleased/FEATURES-479-20240830-090626.yaml
@@ -1,0 +1,5 @@
+kind: FEATURES
+body: '`Project`: Add a new CLI option called `--project-sync-period` to set the time interval for re-queuing Project resources once they are successfully reconciled.'
+time: 2024-08-30T09:06:26.460931+02:00
+custom:
+    PR: "479"

--- a/charts/hcp-terraform-operator/README.md
+++ b/charts/hcp-terraform-operator/README.md
@@ -139,6 +139,7 @@ For a more detailed explanation, please refer to the [FAQ](../../docs/faq.md#gen
 | controllers.agentPool.syncPeriod | string | `"30s"` | The minimum frequency at which watched Agent Pool resources are reconciled. Format: 5s, 1m, etc. |
 | controllers.agentPool.workers | int | `1` | The number of the Agent Pool controller workers. |
 | controllers.module.workers | int | `1` | The number of the Module controller workers. |
+| controllers.project.syncPeriod | string | `"5m"` | The minimum frequency at which watched Project resources are reconciled. Format: 5s, 1m, etc. |
 | controllers.project.workers | int | `1` | The number of the Project controller workers. |
 | controllers.workspace.syncPeriod | string | `"5m"` | The minimum frequency at which watched Workspace resources are reconciled. Format: 5s, 1m, etc. |
 | controllers.workspace.workers | int | `1` | The number of the Workspace controller workers. |

--- a/charts/hcp-terraform-operator/templates/deployment.yaml
+++ b/charts/hcp-terraform-operator/templates/deployment.yaml
@@ -38,6 +38,7 @@ spec:
           - --agent-pool-sync-period={{ .Values.controllers.agentPool.syncPeriod }}
           - --module-workers={{ .Values.controllers.module.workers }}
           - --project-workers={{ .Values.controllers.project.workers }}
+          - --project-sync-period={{ .Values.controllers.project.syncPeriod }}
           - --workspace-workers={{ .Values.controllers.workspace.workers }}
           - --workspace-sync-period={{ .Values.controllers.workspace.syncPeriod }}
           {{- range .Values.operator.watchedNamespaces }}

--- a/charts/hcp-terraform-operator/values.yaml
+++ b/charts/hcp-terraform-operator/values.yaml
@@ -99,6 +99,8 @@ controllers:
   project:
     # -- The number of the Project controller workers.
     workers: 1
+    # -- The minimum frequency at which watched Project resources are reconciled. Format: 5s, 1m, etc.
+    syncPeriod: 5m
   workspace:
     # -- The number of the Workspace controller workers.
     workers: 1

--- a/controllers/flags.go
+++ b/controllers/flags.go
@@ -9,5 +9,6 @@ import (
 
 var (
 	AgentPoolSyncPeriod time.Duration
+	ProjectSyncPeriod   time.Duration
 	WorkspaceSyncPeriod time.Duration
 )

--- a/controllers/project_controller.go
+++ b/controllers/project_controller.go
@@ -100,7 +100,7 @@ func (r *ProjectReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	p.log.Info("Project Controller", "msg", "successfully reconcilied project")
 	r.Recorder.Eventf(&p.instance, corev1.EventTypeNormal, "ReconcileProject", "Successfully reconcilied project ID %s", p.instance.Status.ID)
 
-	return doNotRequeue()
+	return requeueAfter(ProjectSyncPeriod)
 }
 
 func (r *ProjectReconciler) addFinalizer(ctx context.Context, instance *appv1alpha2.Project) error {

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -76,6 +76,8 @@
 
   The `--agent-pool-sync-period` is a `AgentPool` controller option that specifies the time interval for requeuing AgentPool resources, ensuring they will be reconciled. This time is set individually per resource and it helps avoid spike of the resources to reconcile.
 
+  The `--project-sync-period` is a `Project` controller option that specifies the time interval for requeuing Project resources, ensuring they will be reconciled. This time is set individually per resource and it helps avoid spike of the resources to reconcile.
+
   The `--workspace-sync-period` is a `Workspace` controller option that specifies the time interval for requeuing Workspace resources, ensuring they will be reconciled. This time is set individually per resource and it helps avoid spike of the resources to reconcile.
 
   The controller synchronization period should be aligned with the number of managed Customer Resources. If the period is too low and the number of managed resources is too high, you may observe slowness in synchronization.

--- a/main.go
+++ b/main.go
@@ -74,7 +74,9 @@ func main() {
 	// PROJECT CONTROLLER OPTIONS
 	var projectWorkers int
 	flag.IntVar(&projectWorkers, "project-workers", 1,
-		"The number of the Workspace controller workers.")
+		"The number of the Project controller workers.")
+	flag.DurationVar(&controllers.ProjectSyncPeriod, "project-sync-period", 5*time.Minute,
+		"The minimum frequency at which watched project resources are reconciled. Format: 5s, 1m, etc.")
 	// WORKSPACE CONTROLLER OPTIONS
 	var workspaceWorkers int
 	flag.IntVar(&workspaceWorkers, "workspace-workers", 1,
@@ -168,6 +170,7 @@ func main() {
 
 	setupLog.Info(fmt.Sprintf("Operator sync period: %s", syncPeriod))
 	setupLog.Info(fmt.Sprintf("Agent Pool sync period: %s", controllers.AgentPoolSyncPeriod))
+	setupLog.Info(fmt.Sprintf("Project sync period: %s", controllers.ProjectSyncPeriod))
 	setupLog.Info(fmt.Sprintf("Workspace sync period: %s", controllers.WorkspaceSyncPeriod))
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), options)


### PR DESCRIPTION
### Description

This PR introduces a new CLI option called `--project-sync-period` along with a corresponding `controllers.project.syncPeriod` Helm chart option. It sets the time interval for re-queuing Project resources instead of pulling them all at once for reconciliation. This change helps distribute the workload of the Project controller more evenly, especially when managing a large number of resources.

#### Tests

- [![E2E on HCP Terraform Operator](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/end-to-end-tfc.yaml/badge.svg?branch=add-project-sync-period&event=workflow_dispatch)](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/end-to-end-tfc.yaml?query=branch:add-project-sync-period)
- [![E2E on HCP Terraform Operator [Helm]](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/helm-end-to-end-tfc.yaml/badge.svg?branch=add-project-sync-period&event=workflow_dispatch)](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/helm-end-to-end-tfc.yaml?query=branch:add-project-sync-period)
- [![E2E on Terraform Enterprise](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/end-to-end-tfe.yaml/badge.svg?branch=add-project-sync-period&event=workflow_dispatch)](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/end-to-end-tfe.yaml?query=branch:add-project-sync-period)
- [![E2E on Terraform Enterprise [Helm]](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/helm-end-to-end-tfe.yaml/badge.svg?branch=add-project-sync-period&event=workflow_dispatch)](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/helm-end-to-end-tfe.yaml?query=branch:add-project-sync-period)

### Usage Example

```console
$ helm upgrade this hashicorp/hcp-terraform-operator --set controllers.project.syncPeriod=30m
```

### References

N/A.

### Community Note

* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
