### PR TITLE
🚀 Add `--module-sync-period` CLI option

### DIFF
--- a/.changes/unreleased/FEATURES-480-20240830-091412.yaml
+++ b/.changes/unreleased/FEATURES-480-20240830-091412.yaml
@@ -1,0 +1,5 @@
+kind: FEATURES
+body: '`Helm`: Add a new value called `controllers.module.syncPeriod` to set the CLI option `--module-sync-period`.'
+time: 2024-08-30T09:14:12.597913+02:00
+custom:
+    PR: "480"

--- a/.changes/unreleased/FEATURES-480-20240830-091446.yaml
+++ b/.changes/unreleased/FEATURES-480-20240830-091446.yaml
@@ -1,0 +1,5 @@
+kind: FEATURES
+body: '`Module`: Add a new CLI option called `--module-sync-period` to set the time interval for re-queuing Module resources once they are successfully reconciled.'
+time: 2024-08-30T09:14:46.812805+02:00
+custom:
+    PR: "480"

--- a/charts/hcp-terraform-operator/README.md
+++ b/charts/hcp-terraform-operator/README.md
@@ -138,6 +138,7 @@ For a more detailed explanation, please refer to the [FAQ](../../docs/faq.md#gen
 |-----|------|---------|-------------|
 | controllers.agentPool.syncPeriod | string | `"30s"` | The minimum frequency at which watched Agent Pool resources are reconciled. Format: 5s, 1m, etc. |
 | controllers.agentPool.workers | int | `1` | The number of the Agent Pool controller workers. |
+| controllers.module.syncPeriod | string | `"5m"` | The minimum frequency at which watched Module resources are reconciled. Format: 5s, 1m, etc. |
 | controllers.module.workers | int | `1` | The number of the Module controller workers. |
 | controllers.project.workers | int | `1` | The number of the Project controller workers. |
 | controllers.workspace.syncPeriod | string | `"5m"` | The minimum frequency at which watched Workspace resources are reconciled. Format: 5s, 1m, etc. |

--- a/charts/hcp-terraform-operator/templates/deployment.yaml
+++ b/charts/hcp-terraform-operator/templates/deployment.yaml
@@ -37,6 +37,7 @@ spec:
           - --agent-pool-workers={{ .Values.controllers.agentPool.workers }}
           - --agent-pool-sync-period={{ .Values.controllers.agentPool.syncPeriod }}
           - --module-workers={{ .Values.controllers.module.workers }}
+          - --module-sync-period={{ .Values.controllers.module.syncPeriod }}
           - --project-workers={{ .Values.controllers.project.workers }}
           - --workspace-workers={{ .Values.controllers.workspace.workers }}
           - --workspace-sync-period={{ .Values.controllers.workspace.syncPeriod }}

--- a/charts/hcp-terraform-operator/values.yaml
+++ b/charts/hcp-terraform-operator/values.yaml
@@ -96,6 +96,8 @@ controllers:
   module:
     # -- The number of the Module controller workers.
     workers: 1
+    # -- The minimum frequency at which watched Module resources are reconciled. Format: 5s, 1m, etc.
+    syncPeriod: 5m
   project:
     # -- The number of the Project controller workers.
     workers: 1

--- a/controllers/flags.go
+++ b/controllers/flags.go
@@ -9,5 +9,6 @@ import (
 
 var (
 	AgentPoolSyncPeriod time.Duration
+	ModuleSyncPeriod    time.Duration
 	WorkspaceSyncPeriod time.Duration
 )

--- a/controllers/module_controller.go
+++ b/controllers/module_controller.go
@@ -127,7 +127,7 @@ func (r *ModuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	m.log.Info("Module Controller", "msg", "successfully reconcilied module")
 
-	return doNotRequeue()
+	return requeueAfter(ModuleSyncPeriod)
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -76,6 +76,8 @@
 
   The `--agent-pool-sync-period` is a `AgentPool` controller option that specifies the time interval for requeuing AgentPool resources, ensuring they will be reconciled. This time is set individually per resource and it helps avoid spike of the resources to reconcile.
 
+  The `--module-sync-period` is a `Module` controller option that specifies the time interval for requeuing Module resources, ensuring they will be reconciled. This time is set individually per resource and it helps avoid spike of the resources to reconcile.
+
   The `--workspace-sync-period` is a `Workspace` controller option that specifies the time interval for requeuing Workspace resources, ensuring they will be reconciled. This time is set individually per resource and it helps avoid spike of the resources to reconcile.
 
   The controller synchronization period should be aligned with the number of managed Customer Resources. If the period is too low and the number of managed resources is too high, you may observe slowness in synchronization.

--- a/main.go
+++ b/main.go
@@ -86,7 +86,6 @@ func main() {
 
 	// TODO
 	// - Add validation that 'sync-period' has a higher value than '*-sync-period'
-	// - Add '*-sync-period' option for all controllers.
 	// - Add a new CLI option named 'status' (or consider a different name) that will print out the operator settings passed via flags.
 
 	flag.Parse()
@@ -170,6 +169,7 @@ func main() {
 
 	setupLog.Info(fmt.Sprintf("Operator sync period: %s", syncPeriod))
 	setupLog.Info(fmt.Sprintf("Agent Pool sync period: %s", controllers.AgentPoolSyncPeriod))
+	setupLog.Info(fmt.Sprintf("Module sync period: %s", controllers.ModuleSyncPeriod))
 	setupLog.Info(fmt.Sprintf("Workspace sync period: %s", controllers.WorkspaceSyncPeriod))
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), options)

--- a/main.go
+++ b/main.go
@@ -71,6 +71,8 @@ func main() {
 	var moduleWorkers int
 	flag.IntVar(&moduleWorkers, "module-workers", 1,
 		"The number of the Module controller workers.")
+	flag.DurationVar(&controllers.ModuleSyncPeriod, "module-sync-period", 5*time.Minute,
+		"The minimum frequency at which watched workspace resources are reconciled. Format: 5s, 1m, etc.")
 	// PROJECT CONTROLLER OPTIONS
 	var projectWorkers int
 	flag.IntVar(&projectWorkers, "project-workers", 1,


### PR DESCRIPTION
### Description

This PR introduces a new CLI option called `--module-sync-period` along with a corresponding `controllers.module.syncPeriod` Helm chart option. It sets the time interval for re-queuing Module resources instead of pulling them all at once for reconciliation. This change helps distribute the workload of the Module controller more evenly, especially when managing a large number of resources.

#### Tests

- [![E2E on HCP Terraform Operator](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/end-to-end-tfc.yaml/badge.svg?branch=add-module-sync-period&event=workflow_dispatch)](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/end-to-end-tfc.yaml?query=branch:add-module-sync-period)
- [![E2E on HCP Terraform Operator [Helm]](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/helm-end-to-end-tfc.yaml/badge.svg?branch=add-module-sync-period&event=workflow_dispatch)](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/helm-end-to-end-tfc.yaml?query=branch:add-module-sync-period)
- [![E2E on Terraform Enterprise](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/end-to-end-tfe.yaml/badge.svg?branch=add-module-sync-period&event=workflow_dispatch)](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/end-to-end-tfe.yaml?query=branch:add-module-sync-period)
- [![E2E on Terraform Enterprise [Helm]](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/helm-end-to-end-tfe.yaml/badge.svg?branch=add-module-sync-period&event=workflow_dispatch)](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/helm-end-to-end-tfe.yaml?query=branch:add-module-sync-period)

### Usage Example

```console
$ helm upgrade this hashicorp/hcp-terraform-operator --set controllers.module.syncPeriod=30m
```

### References

N/A.

### Community Note

* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
