### PR TITLE
🚀 Update Workspace controller default project ID reconciliation logic

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-481-20240830-094816.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-481-20240830-094816.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: '`Workspace`: Update the default project ID reconciliation logic to avoid making an API call each time a workspace object is updated.'
+time: 2024-08-30T09:48:16.140808+02:00
+custom:
+    PR: "481"

--- a/.changes/unreleased/NOTES-481-20240830-094502.yaml
+++ b/.changes/unreleased/NOTES-481-20240830-094502.yaml
@@ -1,0 +1,5 @@
+kind: NOTES
+body: The `Workspace` CRD has been changed. Please follow the Helm chart instructions on how to upgrade it.
+time: 2024-08-30T09:45:02.393365+02:00
+custom:
+    PR: "481"

--- a/api/v1alpha2/workspace_types.go
+++ b/api/v1alpha2/workspace_types.go
@@ -641,6 +641,10 @@ type WorkspaceStatus struct {
 	//
 	//+optional
 	Variables []VariableStatus `json:"variables,omitempty"`
+	// Default organization project ID.
+	//
+	//+optional
+	DefaultProjectID string `json:"defaultProjectID,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/charts/hcp-terraform-operator/crds/app.terraform.io_workspaces.yaml
+++ b/charts/hcp-terraform-operator/crds/app.terraform.io_workspaces.yaml
@@ -736,6 +736,9 @@ spec:
           status:
             description: WorkspaceStatus defines the observed state of Workspace.
             properties:
+              defaultProjectID:
+                description: Default organization project ID.
+                type: string
               observedGeneration:
                 description: Real world state generation.
                 format: int64

--- a/config/crd/bases/app.terraform.io_workspaces.yaml
+++ b/config/crd/bases/app.terraform.io_workspaces.yaml
@@ -733,6 +733,9 @@ spec:
           status:
             description: WorkspaceStatus defines the observed state of Workspace.
             properties:
+              defaultProjectID:
+                description: Default organization project ID.
+                type: string
               observedGeneration:
                 description: Real world state generation.
                 format: int64

--- a/controllers/workspace_controller_projects.go
+++ b/controllers/workspace_controller_projects.go
@@ -10,7 +10,7 @@ import (
 	tfc "github.com/hashicorp/go-tfe"
 )
 
-func (r *WorkspaceReconciler) getProjectIDByName(ctx context.Context, w *workspaceInstance) (string, error) {
+func (w *workspaceInstance) getProjectIDByName(ctx context.Context) (string, error) {
 	projectName := w.instance.Spec.Project.Name
 
 	listOpts := &tfc.ProjectListOptions{
@@ -38,7 +38,7 @@ func (r *WorkspaceReconciler) getProjectIDByName(ctx context.Context, w *workspa
 	return "", fmt.Errorf("project ID not found for project name %q", projectName)
 }
 
-func (r *WorkspaceReconciler) getProjectID(ctx context.Context, w *workspaceInstance) (string, error) {
+func (w *workspaceInstance) getProjectID(ctx context.Context) (string, error) {
 	specProject := w.instance.Spec.Project
 
 	if specProject == nil {
@@ -47,7 +47,7 @@ func (r *WorkspaceReconciler) getProjectID(ctx context.Context, w *workspaceInst
 
 	if specProject.Name != "" {
 		w.log.Info("Reconcile Project", "msg", "getting project ID by name")
-		return r.getProjectIDByName(ctx, w)
+		return w.getProjectIDByName(ctx)
 	}
 
 	w.log.Info("Reconcile Project", "msg", "getting project ID from the spec.Project.ID")

--- a/controllers/workspace_controller_projects_test.go
+++ b/controllers/workspace_controller_projects_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Workspace controller", Ordered, func() {
 	})
 
 	Context("Project", func() {
-		It("can handle project by name", func() {
+		It("can be handled by name", func() {
 			instance.Spec.Project = &appv1alpha2.WorkspaceProject{Name: projectName}
 			// Create a new Kubernetes workspace object and wait until the controller finishes the reconciliation
 			createWorkspace(instance)
@@ -103,7 +103,7 @@ var _ = Describe("Workspace controller", Ordered, func() {
 			isReconciledDefaultProject(instance)
 		})
 
-		It("can handle project by id", func() {
+		It("can be handled by ID", func() {
 			instance.Spec.Project = &appv1alpha2.WorkspaceProject{ID: projectID}
 			// Create a new Kubernetes workspace object and wait until the controller finishes the reconciliation
 			createWorkspace(instance)
@@ -145,8 +145,8 @@ func isReconciledProjectByID(instance *appv1alpha2.Workspace) {
 	Eventually(func() bool {
 		Expect(k8sClient.Get(ctx, namespacedName, instance)).Should(Succeed())
 		ws, err := tfClient.Workspaces.ReadByID(ctx, instance.Status.WorkspaceID)
-		Expect(ws).ShouldNot(BeNil())
 		Expect(err).Should(Succeed())
+		Expect(ws).ShouldNot(BeNil())
 		return ws.Project.ID == instance.Spec.Project.ID
 	}).Should(BeTrue())
 }
@@ -157,11 +157,11 @@ func isReconciledProjectByName(instance *appv1alpha2.Workspace) {
 	Eventually(func() bool {
 		Expect(k8sClient.Get(ctx, namespacedName, instance)).Should(Succeed())
 		ws, err := tfClient.Workspaces.ReadByID(ctx, instance.Status.WorkspaceID)
+		Expect(err).Should(Succeed())
 		Expect(ws).ShouldNot(BeNil())
-		Expect(err).Should(Succeed())
 		prj, err := tfClient.Projects.Read(ctx, ws.Project.ID)
-		Expect(prj).ShouldNot(BeNil())
 		Expect(err).Should(Succeed())
+		Expect(prj).ShouldNot(BeNil())
 		return prj.Name == instance.Spec.Project.Name
 	}).Should(BeTrue())
 }
@@ -172,11 +172,12 @@ func isReconciledDefaultProject(instance *appv1alpha2.Workspace) {
 	Eventually(func() bool {
 		Expect(k8sClient.Get(ctx, namespacedName, instance)).Should(Succeed())
 		ws, err := tfClient.Workspaces.ReadByID(ctx, instance.Status.WorkspaceID)
+		Expect(err).Should(Succeed())
 		Expect(ws).ShouldNot(BeNil())
-		Expect(err).Should(Succeed())
 		org, err := tfClient.Organizations.Read(ctx, instance.Spec.Organization)
-		Expect(org).ShouldNot(BeNil())
 		Expect(err).Should(Succeed())
-		return ws.Project.ID == org.DefaultProject.ID
+		Expect(org).ShouldNot(BeNil())
+		Expect(org.DefaultProject).ShouldNot(BeNil())
+		return org.DefaultProject.ID == ws.Project.ID && org.DefaultProject.ID == instance.Status.DefaultProjectID
 	}).Should(BeTrue())
 }


### PR DESCRIPTION
### Description

Update the default project ID reconciliation logic in the Workspace controller to avoid making an API call each time a workspace object is updated. Since the default project ID is immutable, we can get it and keep in `status.defaultProjectID` for future usage.

#### Tests

- [![E2E on HCP Terraform Operator](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/end-to-end-tfc.yaml/badge.svg?branch=update-workspace-default-project&event=workflow_dispatch)](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/end-to-end-tfc.yaml?query=branch:update-workspace-default-project)
- [![E2E on HCP Terraform Operator [Helm]](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/helm-end-to-end-tfc.yaml/badge.svg?branch=update-workspace-default-project&event=workflow_dispatch)](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/helm-end-to-end-tfc.yaml?query=branch:update-workspace-default-project)
- [![E2E on Terraform Enterprise](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/end-to-end-tfe.yaml/badge.svg?branch=update-workspace-default-project&event=workflow_dispatch)](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/end-to-end-tfe.yaml?query=branch:update-workspace-default-project)
- [![E2E on Terraform Enterprise [Helm]](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/helm-end-to-end-tfe.yaml/badge.svg?branch=update-workspace-default-project&event=workflow_dispatch)](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/helm-end-to-end-tfe.yaml?query=branch:update-workspace-default-project)

### Usage Example

A new field `defaultProjectID` has been added to Status:

```yaml
status:
  defaultProjectID: prj-vakhExdgszGgcNfZ
```

### References

N/A.

### Community Note

* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
