### PR TITLE
🚀 Update Module controller reconciliation logic to pick up outputs faster

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-482-20240830-161222.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-482-20240830-161222.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: '`Module`: Update reconciliation logic to proceed to the next step immediately after the configuration version is uploaded successfully and reduce delays in output fetching.'
+time: 2024-08-30T16:12:22.551945+02:00
+custom:
+    PR: "482"

--- a/controllers/module_controller.go
+++ b/controllers/module_controller.go
@@ -462,7 +462,9 @@ func (r *ModuleReconciler) reconcileModule(ctx context.Context, m *moduleInstanc
 			return err
 		}
 		m.log.Info("Reconcile Configuration Version", "msg", fmt.Sprintf("successfully got the upload status: %s", cv.Status))
-		return r.updateStatusCV(ctx, &m.instance, workspace, cv)
+		if err := r.updateStatusCV(ctx, &m.instance, workspace, cv); err != nil {
+			return err
+		}
 	}
 
 	// checks if a new Run needs to be initialized
@@ -493,7 +495,9 @@ func (r *ModuleReconciler) reconcileModule(ctx context.Context, m *moduleInstanc
 			return err
 		}
 		m.log.Info("Reconcile Run", "msg", fmt.Sprintf("successfully got the run status: %s", run.Status))
-		return r.updateStatusRun(ctx, &m.instance, workspace, run)
+		if err := r.updateStatusRun(ctx, &m.instance, workspace, run); err != nil {
+			return err
+		}
 	}
 
 	// Reconcile Outputs

--- a/controllers/module_controller_outputs.go
+++ b/controllers/module_controller_outputs.go
@@ -153,25 +153,16 @@ func (r *ModuleReconciler) setOutputs(ctx context.Context, m *moduleInstance) er
 func needToUpdateOutput(instance *appv1alpha2.Module) bool {
 	status := instance.Status
 
-	if status.Run == nil {
+	if status.Run == nil || !status.Run.RunApplied() {
 		return false
 	}
-	if status.Output == nil {
-		return true
-	}
-	if status.Run.RunApplied() && status.Run.ID != status.Output.RunID {
-		return true
-	}
 
-	return false
+	return status.Output == nil || status.Output.RunID != status.Run.ID
 }
 
 func (r *ModuleReconciler) reconcileOutputs(ctx context.Context, m *moduleInstance, workspace *tfc.Workspace) error {
-	m.log.Info("Reconcile Module Outputs", "mgs", "new reconciliation event")
-
 	if workspace.CurrentRun != nil {
 		if needToUpdateOutput(&m.instance) {
-			m.log.Info("Reconcile Module Outputs", "mgs", "run successfully applied")
 			m.log.Info("Reconcile Module Outputs", "mgs", "creating or updating outputs")
 			err := r.setOutputs(ctx, m)
 			if err != nil {

--- a/controllers/module_controller_test.go
+++ b/controllers/module_controller_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/hcp-terraform-operator/internal/pointer"
 )
 
-var _ = Describe("Module controller", Ordered, func() {
+var _ = Describe("Module Controller", Ordered, func() {
 	var (
 		instance       *appv1alpha2.Module
 		namespacedName = newNamespacedName()
@@ -97,8 +97,8 @@ var _ = Describe("Module controller", Ordered, func() {
 		}).Should(BeTrue())
 	})
 
-	Context("Module controller", func() {
-		It("can create, run and destroy module, ref to Workspace by Name", func() {
+	Context("Can Handle", func() {
+		It("Reference to Workspace by Name", func() {
 			// Create a new TFC Workspace
 			ws, err := tfClient.Workspaces.Create(ctx, organization, tfc.WorkspaceCreateOptions{
 				Name:      &workspace,
@@ -146,7 +146,7 @@ var _ = Describe("Module controller", Ordered, func() {
 			Expect(k8sClient.Get(ctx, namespacedName, instance)).Should(Succeed())
 			Expect(instance.Status.Run.Status).NotTo(BeEquivalentTo(string(tfc.RunErrored)))
 		})
-		It("can create, run and destroy module, ref to Workspace by ID", func() {
+		It("Reference to Workspace by ID", func() {
 			// Create a new TFC Workspace
 			ws, err := tfClient.Workspaces.Create(ctx, organization, tfc.WorkspaceCreateOptions{
 				Name:      &workspace,
@@ -195,7 +195,7 @@ var _ = Describe("Module controller", Ordered, func() {
 			Expect(k8sClient.Get(ctx, namespacedName, instance)).Should(Succeed())
 			Expect(instance.Status.Run.Status).NotTo(BeEquivalentTo(string(tfc.RunErrored)))
 		})
-		It("can handle external deletion", func() {
+		It("External Deletion", func() {
 			// Create a new TFC Workspace
 			ws, err := tfClient.Workspaces.Create(ctx, organization, tfc.WorkspaceCreateOptions{
 				Name:      &workspace,


### PR DESCRIPTION
### Description

This PR updates the reconciliation logic of the Module controller to proceed to the next step once the configuration version is successfully uploaded and fetches the outputs after the run is completed. Previously, after each step, the reconciliation would unconditionally require the object for a specified time. As a result, fetching the outputs could take up to the entire reconciliation interval.

#### Tests

- [![E2E on HCP Terraform Operator](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/end-to-end-tfc.yaml/badge.svg?branch=update-module-reconciliation-logic&event=workflow_dispatch)](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/end-to-end-tfc.yaml?query=branch:update-module-reconciliation-logic)
- [![E2E on HCP Terraform Operator [Helm]](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/helm-end-to-end-tfc.yaml/badge.svg?branch=update-module-reconciliation-logic&event=workflow_dispatch)](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/helm-end-to-end-tfc.yaml?query=branch:update-module-reconciliation-logic)
- [![E2E on Terraform Enterprise](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/end-to-end-tfe.yaml/badge.svg?branch=update-module-reconciliation-logic&event=workflow_dispatch)](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/end-to-end-tfe.yaml?query=branch:update-module-reconciliation-logic)
- [![E2E on Terraform Enterprise [Helm]](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/helm-end-to-end-tfe.yaml/badge.svg?branch=update-module-reconciliation-logic&event=workflow_dispatch)](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/helm-end-to-end-tfe.yaml?query=branch:update-module-reconciliation-logic)

### Usage Example

N/A.

### References

N/A.

### Community Note

* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
