### PR TITLE
🤖 Update URL in tests

### DIFF
--- a/api/v1alpha2/workspace_validation_test.go
+++ b/api/v1alpha2/workspace_validation_test.go
@@ -115,7 +115,7 @@ func TestValidateWorkspaceSpecNotifications(t *testing.T) {
 	t.Parallel()
 
 	token := "token"
-	url := "https://example.com"
+	url := "https://www.hashicorp.com"
 	successCases := map[string]Workspace{
 		"OnlyEmailAddresses": {
 			Spec: WorkspaceSpec{

--- a/controllers/workspace_controller_notifications_test.go
+++ b/controllers/workspace_controller_notifications_test.go
@@ -85,7 +85,7 @@ var _ = Describe("Workspace controller", Label("Notifications"), Ordered, func()
 			instance.Spec.Notifications = append(instance.Spec.Notifications, appv1alpha2.Notification{
 				Name: "slack",
 				Type: tfc.NotificationDestinationTypeSlack,
-				URL:  "https://example.com",
+				URL:  "https://www.hashicorp.com",
 			})
 			// Create a new Kubernetes workspace object and wait until the controller finishes the reconciliation
 			createWorkspace(instance)
@@ -100,7 +100,7 @@ var _ = Describe("Workspace controller", Label("Notifications"), Ordered, func()
 			instance.Spec.Notifications = append(instance.Spec.Notifications, appv1alpha2.Notification{
 				Name: "slack",
 				Type: tfc.NotificationDestinationTypeSlack,
-				URL:  "https://example.com",
+				URL:  "https://www.hashicorp.com",
 			})
 			instance.Spec.Notifications = append(instance.Spec.Notifications, appv1alpha2.Notification{
 				Name:       "email",
@@ -120,7 +120,7 @@ var _ = Describe("Workspace controller", Label("Notifications"), Ordered, func()
 			instance.Spec.Notifications = append(instance.Spec.Notifications, appv1alpha2.Notification{
 				Name: "slack",
 				Type: tfc.NotificationDestinationTypeSlack,
-				URL:  "https://example.com",
+				URL:  "https://www.hashicorp.com",
 			})
 			// Create a new Kubernetes workspace object and wait until the controller finishes the reconciliation
 			createWorkspace(instance)

--- a/controllers/workspace_controller_run_tasks_test.go
+++ b/controllers/workspace_controller_run_tasks_test.go
@@ -238,7 +238,7 @@ func isRunTasksReconciled(instance *appv1alpha2.Workspace) {
 func createRunTaskForTest(name string) string {
 	rt, err := tfClient.RunTasks.Create(ctx, organization, tfc.RunTaskCreateOptions{
 		Name:     name,
-		URL:      "https://example.com",
+		URL:      "https://www.hashicorp.com",
 		Category: "task", // MUST BE "task"
 		Enabled:  tfc.Bool(true),
 	})


### PR DESCRIPTION
### Description

Update the URL in tests to `https://www.hashicorp.com` since `https://example.com` started returning 405 error code.

#### Tests

- [![E2E on HCP Terraform Operator](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/end-to-end-tfc.yaml/badge.svg?branch=fix-tests&event=workflow_dispatch)](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/end-to-end-tfc.yaml?query=branch:fix-tests)
- [![E2E on HCP Terraform Operator [Helm]](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/helm-end-to-end-tfc.yaml/badge.svg?branch=fix-tests&event=workflow_dispatch)](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/helm-end-to-end-tfc.yaml?query=branch:fix-tests)
- [![E2E on Terraform Enterprise](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/end-to-end-tfe.yaml/badge.svg?branch=fix-tests&event=workflow_dispatch)](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/end-to-end-tfe.yaml?query=branch:fix-tests)
- [![E2E on Terraform Enterprise [Helm]](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/helm-end-to-end-tfe.yaml/badge.svg?branch=fix-tests&event=workflow_dispatch)](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/helm-end-to-end-tfe.yaml?query=branch:fix-tests)

### Usage Example

N/A.

### References

N/A.

### Community Note

* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
