### PR TITLE
🚀Add Configurable RBAC Support

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-491-20241002-142919.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-491-20241002-142919.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: '`Helm Chart`: Add the ability to configure the creation of the RBAC role and role binding.'
+time: 2024-10-02T14:29:19.427979944Z
+custom:
+    PR: "491"

--- a/charts/hcp-terraform-operator/README.md
+++ b/charts/hcp-terraform-operator/README.md
@@ -167,6 +167,7 @@ For a more detailed explanation, please refer to the [FAQ](../../docs/faq.md#gen
 | operator.tfeAddress | string | `""` | The API URL of a Terraform Enterprise instance. |
 | operator.watchedNamespaces | list | `[]` | List of namespaces the controllers should watch. |
 | priorityClassName | string | `""` | Deployment priorityClassName. More information in [Kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/). |
+| rbac.create | bool | `true` | Specifies whether a Role-Based Access Control (RBAC) resources should be created |
 | replicaCount | int | `2` | The number of Operator replicas. |
 | securityContext | object | `{"runAsNonRoot":true}` | Deployment pod security context. More information in [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/). |
 | serviceAccount.annotations | object | `{}` | Additional annotations for the ServiceAccount. |

--- a/charts/hcp-terraform-operator/templates/clusterrole.yaml
+++ b/charts/hcp-terraform-operator/templates/clusterrole.yaml
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
-
+---
+{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -176,3 +177,4 @@ rules:
   - subjectaccessreviews
   verbs:
   - create
+{{- end -}}

--- a/charts/hcp-terraform-operator/templates/clusterrolebinding.yaml
+++ b/charts/hcp-terraform-operator/templates/clusterrolebinding.yaml
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
-
+---
+{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -26,3 +27,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "hcp-terraform-operator.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/charts/hcp-terraform-operator/templates/role.yaml
+++ b/charts/hcp-terraform-operator/templates/role.yaml
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
-
+---
+{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -38,3 +39,4 @@ rules:
   verbs:
   - create
   - patch
+{{- end -}}

--- a/charts/hcp-terraform-operator/templates/rolebinding.yaml
+++ b/charts/hcp-terraform-operator/templates/rolebinding.yaml
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
-
+---
+{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -14,3 +15,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "hcp-terraform-operator.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/charts/hcp-terraform-operator/values.yaml
+++ b/charts/hcp-terraform-operator/values.yaml
@@ -120,3 +120,7 @@ serviceAccount:
   # -- The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template.
   name: ""
+
+rbac:
+  # -- Specifies whether a Role-Based Access Control (RBAC) resources should be created
+  create: true


### PR DESCRIPTION
<!---
Please DO NOT remove any fields from this template. If there is nothing to add, fill in N/A.
Use emojis in the pull request title according to its type:
 - Bug fix: 🐛 Fix ...
 - New feature or enhancement: 🚀 Add ...
 - Documentation: 📖 ...
 - Dependency update: 🌱 Bump ...
For the rest type of the pull requests please use ✨.

Thank you!
--->

### Description

This pull request introduces configurable Role-Based Access Control (RBAC) support to the HCP Terraform Operator. 
The following changes have been made:

- **Helm Chart Updates:**
  - Added Helm chart value to `values.yaml` file to enable or disable the creation of RBAC resources.
  - Modified the Helm templates to conditionally create RBAC resources based on the provided value.

### Motivation

The addition of configurable RBAC support allows users to have more control over the security and permissions of the HCP Terraform Operator. This is particularly useful for environments with strict security requirements or custom RBAC policies.

### Usage Example
To enable/disable RBAC creation, set the `rbac.create` value to `true` or `false` in your `values.yaml` file:

```yaml
rbac:
  create: true
```

### References

- Addresses issue #490.

### Community Note
<!--- Please keep this note for the community --->
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
