### PR TITLE
🐳 Update Dockerfile with a new Red Hat UBI image target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,7 +91,7 @@ ENTRYPOINT ["/bin/sh", "-c", "/$BIN_NAME"]
 
 # Red Hat UBI release image
 # -----------------------------------
-FROM registry.access.redhat.com/ubi9/ubi-micro AS release-ubi
+FROM registry.access.redhat.com/ubi9/ubi-micro:9.4-15 AS release-ubi
 
 ARG BIN_NAME
 ARG PRODUCT_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -89,6 +89,36 @@ USER 65532:65532
 
 ENTRYPOINT ["/bin/sh", "-c", "/$BIN_NAME"]
 
+# Red Hat UBI release image
+# -----------------------------------
+FROM registry.access.redhat.com/ubi9/ubi-micro AS release-ubi
+
+ARG BIN_NAME
+ARG PRODUCT_VERSION
+ARG PRODUCT_REVISION
+ARG TARGETOS
+ARG TARGETARCH
+
+ENV BIN_NAME=$BIN_NAME
+
+LABEL name="HCP Terraform Operator"
+LABEL vendor="HashiCorp"
+LABEL release=$PRODUCT_REVISION
+LABEL summary="HCP Terraform Operator for Kubernetes allows managing HCP Terraform / Terraform Enterprise resources via Kubernetes Custom Resources"
+LABEL description="HCP Terraform Operator for Kubernetes allows managing HCP Terraform / Terraform Enterprise resources via Kubernetes Custom Resources"
+
+LABEL maintainer="Terraform Ecosystem - Hybrid Cloud Team <hcp-tf-operator@hashicorp.com>"
+LABEL version=$PRODUCT_VERSION
+LABEL revision=$PRODUCT_REVISION
+
+WORKDIR /
+COPY LICENSE /licenses/copyright.txt
+COPY dist/$TARGETOS/$TARGETARCH/$BIN_NAME .
+
+USER 65532:65532
+
+ENTRYPOINT ["/bin/sh", "-c", "/$BIN_NAME"]
+
 # ===================================
 #
 #   Set default target to 'dev'.


### PR DESCRIPTION
### Description

This PR adds a new Dockerfile target that uses [Red Hat UBI](https://catalog.redhat.com/software/base-images) micro image. The new target aims to pass [preflight](https://github.com/redhat-openshift-ecosystem/openshift-preflight) validation.

### Usage Example

N/A.

### References

N/A.

### Community Note

* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
