### PR TITLE
Feat add tolerations and affinity to operator deployment

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-495-20241127-090349.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-495-20241127-090349.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: '`Helm Chart`: Add the ability to configure `affinity` and `tolerations` for the Deployment of the operator.'
+time: 2024-11-27T09:03:49.589507226+01:00
+custom:
+    PR: "495"

--- a/charts/hcp-terraform-operator/README.md
+++ b/charts/hcp-terraform-operator/README.md
@@ -168,6 +168,7 @@ For a more detailed explanation, please refer to the [FAQ](../../docs/faq.md#gen
 | kubeRbacProxy.resources.requests.cpu | string | `"50m"` | Guaranteed minimum amount of CPU to be used by a container. |
 | kubeRbacProxy.resources.requests.memory | string | `"64Mi"` | Guaranteed minimum amount of memory to be used by a container. |
 | kubeRbacProxy.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"seccompProfile":{"type":"RuntimeDefault"}}` | Container security context. More information in [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/). |
+| operator.affinity | object | `{}` | Kubernetes Affinity. More information: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity |
 | operator.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
 | operator.image.repository | string | `"hashicorp/hcp-terraform-operator"` | Image repository. |
 | operator.image.tag | string | `""` | Image tag. Defaults to `.Chart.AppVersion`. |
@@ -179,6 +180,7 @@ For a more detailed explanation, please refer to the [FAQ](../../docs/faq.md#gen
 | operator.skipTLSVerify | bool | `false` | Whether or not to ignore TLS certification warnings. |
 | operator.syncPeriod | string | `"1h"` | The minimum frequency at which watched resources are reconciled. Format: `5s`, `1m`, etc. |
 | operator.tfeAddress | string | `""` | The API URL of a Terraform Enterprise instance. |
+| operator.tolerations | list | `[]` | Kubernetes Tolerations. More information: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
 | operator.watchedNamespaces | list | `[]` | List of namespaces the controllers should watch. |
 | priorityClassName | string | `""` | Deployment priorityClassName. More information in [Kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/). |
 | rbac.create | bool | `true` | Specifies whether a Role-Based Access Control (RBAC) resources should be created |

--- a/charts/hcp-terraform-operator/templates/deployment.yaml
+++ b/charts/hcp-terraform-operator/templates/deployment.yaml
@@ -100,6 +100,14 @@ spec:
             {{- toYaml .Values.kubeRbacProxy.resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.kubeRbacProxy.securityContext | nindent 12 }}
+      {{- with .Values.operator.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.operator.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "hcp-terraform-operator.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.securityContext | nindent 8 }}

--- a/charts/hcp-terraform-operator/values.yaml
+++ b/charts/hcp-terraform-operator/values.yaml
@@ -55,8 +55,7 @@ operator:
   #           values:
   #         - amd64
   #
-  # -- Kubernetes Affinity.
-  # More information: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+  # -- Kubernetes Affinity. More information: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
   affinity: {}
 
   # Usage example:
@@ -66,9 +65,8 @@ operator:
   #   value: "spot"
   #   effect: "NoSchedule"
   #
-  # -- Kubernetes Tolerations.
-  # More information: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-  tolerations: {}
+  # -- Kubernetes Tolerations. More information: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+  tolerations: []
 
   # -- The minimum frequency at which watched resources are reconciled. Format: `5s`, `1m`, etc.
   syncPeriod: 1h

--- a/charts/hcp-terraform-operator/values.yaml
+++ b/charts/hcp-terraform-operator/values.yaml
@@ -44,6 +44,32 @@ operator:
     seccompProfile:
       type: RuntimeDefault
 
+  # Usage example:
+  # affinity:
+  #   nodeAffinity:
+  #     requiredDuringSchedulingIgnoredDuringExecution:
+  #       nodeSelectorTerms:
+  #       - matchExpressions:
+  #         - key: kubernetes.io/arch
+  #           operator: In
+  #           values:
+  #         - amd64
+  #
+  # -- Kubernetes Affinity.
+  # More information: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+  affinity: {}
+
+  # Usage example:
+  # tolerations:
+  # - key: "kubernetes.azure.com/scalesetpriority"
+  #   operator: "Equal"
+  #   value: "spot"
+  #   effect: "NoSchedule"
+  #
+  # -- Kubernetes Tolerations.
+  # More information: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+  tolerations: {}
+
   # -- The minimum frequency at which watched resources are reconciled. Format: `5s`, `1m`, etc.
   syncPeriod: 1h
 


### PR DESCRIPTION
<!---
Please DO NOT remove any fields from this template. If there is nothing to add, fill in N/A.
Use emojis in the pull request title according to its type:
 - Bug fix: 🐛 Fix ...
 - New feature or enhancement: 🚀 Add ...
 - Documentation: 📖 ...
 - Dependency update: 🌱 Bump ...
For the rest type of the pull requests please use ✨.

Thank you!
--->

### Description

<!---
Please describe your changes in detail.
--->
This PR adds the `affinity` and `tolerations` values to the Helm Chart for the deployment of the Operator.

### Usage Example

<!---
Please provide a usage example if you have implemented a new feature.
--->
```yaml
operator:
  affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
          - matchExpressions:
            - key: kubernetes.io/arch
              operator: In
              values:
              - amd64
  tolerations:
  - key: "vmtype"
    operator: "Equal"
    value: "spot"
    effect: "NoSchedule"
```

### Community Note
<!--- Please keep this note for the community --->
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
