### PR TITLE
🧹 Remove unused config map from Deployment template

### DIFF
--- a/charts/hcp-terraform-operator/templates/deployment.yaml
+++ b/charts/hcp-terraform-operator/templates/deployment.yaml
@@ -105,9 +105,6 @@ spec:
         {{- toYaml .Values.securityContext | nindent 8 }}
       terminationGracePeriodSeconds: 10
       volumes:
-      - configMap:
-          name: {{ .Release.Name }}-manager-config
-        name: manager-config
 {{- if .Values.customCAcertificates }}
       - configMap:
           name: {{ .Release.Name }}-ca-certificates


### PR DESCRIPTION
### Description

This PR removes unused config map from Deployment template.

### Usage Example

N/A.

### References

N/A.

### Community Note

* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
