### PR TITLE
🌱 Bump aquasecurity/trivy-action to 0.29.0

### DIFF
--- a/.github/workflows/docker-image-security-scan.yml
+++ b/.github/workflows/docker-image-security-scan.yml
@@ -39,7 +39,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@e5f43133f6e8736992c9f3c1b3296e24b37e17f2 # 0.10.0
+        uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # 0.29.0
         with:
           scan-type: image
           format: sarif


### PR DESCRIPTION
### Description

Bump `aquasecurity/trivy-action` to 0.29.0.

### Usage Example

N/A.

### References

N/A.

### Community Note

* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
