### PR TITLE
🐛 Fix Workspace `spec.versionControl` validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ copywrite: install-copywrite ## Run copywrite against code.
 
 .PHONY: test
 test: manifests generate fmt vet copywrite envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -timeout 30m -v ./internal/controller -coverprofile cover.out ${TESTARGS}
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -timeout 45m -v ./internal/controller -coverprofile cover.out ${TESTARGS}
 
 .PHONY: test-api
 test-api: fmt vet copywrite ## Run API tests.

--- a/api/v1alpha2/workspace_types.go
+++ b/api/v1alpha2/workspace_types.go
@@ -301,17 +301,26 @@ type VersionControl struct {
 	//+kubebuilder:default=true
 	//+optional
 	SpeculativePlans bool `json:"speculativePlans"`
-	// File triggers allow you to queue runs in Terraform Cloud when files in your VCS repository change.
+	// File triggers allow you to queue runs in HCP Terraform when files in your VCS repository change.
+	// Default: `false`.
+	// More informarion:
+	//  - https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings/vcs#automatic-run-triggering
 	//
 	//+optional
 	//+kubebuilder:default:=false
 	FileTriggersEnabled bool `json:"fileTriggersEnabled"`
-	// The list of pattern triggers that will queue runs in Terraform Cloud when files in your VCS repository change.
+	// The list of pattern triggers that will queue runs in HCP Terraform when files in your VCS repository change.
+	// `spec.versionControl.fileTriggersEnabled` must be set to `true`.
+	// More informarion:
+	//  - https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings/vcs#automatic-run-triggering
 	//
 	//+kubebuilder:validation:MinItems:=1
 	//+optional
 	TriggerPatterns []string `json:"triggerPatterns,omitempty"`
-	// The list of pattern prefixes that will queue runs in Terraform Cloud when files in your VCS repository change.
+	// The list of pattern prefixes that will queue runs in HCP Terraform when files in your VCS repository change.
+	// `spec.versionControl.fileTriggersEnabled` must be set to `true`.
+	// More informarion:
+	//  - https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings/vcs#automatic-run-triggering
 	//
 	//+kubebuilder:validation:MinItems:=1
 	//+optional

--- a/api/v1alpha2/workspace_validation.go
+++ b/api/v1alpha2/workspace_validation.go
@@ -23,11 +23,11 @@ func (w *Workspace) ValidateSpec() error {
 	allErrs = append(allErrs, w.validateSpecRunTriggers()...)
 	allErrs = append(allErrs, w.validateSpecSSHKey()...)
 	allErrs = append(allErrs, w.validateSpecProject()...)
-	allErrs = append(allErrs, w.validateSpecFileTriggers()...)
 	allErrs = append(allErrs, w.validateSpecTerraformVariables()...)
 	allErrs = append(allErrs, w.validateSpecEnvironmentVariables()...)
 	allErrs = append(allErrs, w.validateSpecDeletionPolicy()...)
 	allErrs = append(allErrs, w.validateSpecVariableSets()...)
+	allErrs = append(allErrs, w.validateSpecVersionControl()...)
 
 	if len(allErrs) == 0 {
 		return nil
@@ -613,13 +613,23 @@ func (w *Workspace) validateSpecVariableSets() field.ErrorList {
 	return allErrs
 }
 
-func (w *Workspace) validateSpecFileTriggers() field.ErrorList {
+func (w *Workspace) validateSpecVersionControl() field.ErrorList {
 	allErrs := field.ErrorList{}
-	spec := w.Spec
+	spec := w.Spec.VersionControl
 
-	f := field.NewPath("spec").Child("VersionControl")
+	if spec == nil {
+		return allErrs
+	}
 
-	if spec.VersionControl != nil && len(spec.VersionControl.TriggerPatterns) > 0 && len(spec.VersionControl.TriggerPrefixes) > 0 {
+	return w.validateSpecVersionControlFileTriggers()
+}
+
+func (w *Workspace) validateSpecVersionControlFileTriggers() field.ErrorList {
+	allErrs := field.ErrorList{}
+	spec := w.Spec.VersionControl
+
+	f := field.NewPath("spec").Child("versionControl")
+	if len(spec.TriggerPatterns) > 0 && len(spec.TriggerPrefixes) > 0 {
 		allErrs = append(allErrs, field.Invalid(
 			f,
 			"",
@@ -627,31 +637,27 @@ func (w *Workspace) validateSpecFileTriggers() field.ErrorList {
 		)
 	}
 
-	f = field.NewPath("spec").Child("VersionControl").Child("fileTriggerEnabled")
-
-	if !spec.VersionControl.FileTriggersEnabled && spec.VersionControl != nil && len(spec.VersionControl.TriggerPatterns) > 0 {
+	f = field.NewPath("spec").Child("versionControl").Child("fileTriggerEnabled")
+	if !spec.FileTriggersEnabled && len(spec.TriggerPatterns) > 0 {
 		allErrs = append(allErrs, field.Invalid(
 			f,
 			"",
-			"TriggerPatterns requires FileTriggersEnabled set to true"),
+			"'spec.versionControl.fileTriggerEnabled' must be set to 'true' when 'spec.versionControl.triggerPatterns' is set"),
 		)
 	}
 
-	if !spec.VersionControl.FileTriggersEnabled && spec.VersionControl != nil && len(spec.VersionControl.TriggerPrefixes) > 0 {
-		allErrs = append(allErrs, field.Invalid(
+	if !spec.FileTriggersEnabled && len(spec.TriggerPrefixes) > 0 {
+		allErrs = append(allErrs, field.Required(
 			f,
-			"",
-			"TriggerPrefixes requires FileTriggersEnabled set to true"),
+			"'spec.versionControl.fileTriggerEnabled' must be set to 'true' when 'spec.versionControl.triggerPrefixes' is set"),
 		)
 	}
 
 	f = field.NewPath("spec").Child("workingDirectory")
-
-	if spec.WorkingDirectory == "" && spec.VersionControl != nil && len(spec.VersionControl.TriggerPrefixes) > 0 {
-		allErrs = append(allErrs, field.Invalid(
+	if w.Spec.WorkingDirectory == "" && len(spec.TriggerPrefixes) > 0 {
+		allErrs = append(allErrs, field.Required(
 			f,
-			"",
-			"TriggerPrefixes requires a non-empty WorkingDirectory"),
+			"'spec.workingDirectory' must not be empty when 'spec.versionControl.triggerPrefixes' is set"),
 		)
 	}
 

--- a/api/v1alpha2/workspace_validation_test.go
+++ b/api/v1alpha2/workspace_validation_test.go
@@ -1090,7 +1090,7 @@ func TestValidateSpecDeletionPolicy(t *testing.T) {
 	}
 }
 
-func TestValidateWorkspaceSpecVariableSets(t *testing.T) {
+func TestValidateSpecVariableSets(t *testing.T) {
 	t.Parallel()
 
 	successCases := map[string]Workspace{
@@ -1148,10 +1148,15 @@ func TestValidateWorkspaceSpecVariableSets(t *testing.T) {
 	}
 }
 
-func TestValidateWorkspaceSpecFileTriggers(t *testing.T) {
+func TestValidateSpecVersionControl(t *testing.T) {
 	t.Parallel()
 
 	successCases := map[string]Workspace{
+		"HasNoVersionControlConfigured": {
+			Spec: WorkspaceSpec{
+				VersionControl: nil,
+			},
+		},
 		"HasOnlyTriggerPatterns": {
 			Spec: WorkspaceSpec{
 				VersionControl: &VersionControl{
@@ -1173,7 +1178,7 @@ func TestValidateWorkspaceSpecFileTriggers(t *testing.T) {
 
 	for n, c := range successCases {
 		t.Run(n, func(t *testing.T) {
-			if errs := c.validateSpecFileTriggers(); len(errs) != 0 {
+			if errs := c.validateSpecVersionControl(); len(errs) != 0 {
 				t.Errorf("Unexpected validation errors: %v", errs)
 			}
 		})
@@ -1216,7 +1221,7 @@ func TestValidateWorkspaceSpecFileTriggers(t *testing.T) {
 
 	for n, c := range errorCases {
 		t.Run(n, func(t *testing.T) {
-			if errs := c.validateSpecFileTriggers(); len(errs) == 0 {
+			if errs := c.validateSpecVersionControl(); len(errs) == 0 {
 				t.Error("Unexpected failure, at least one error is expected")
 			}
 		})

--- a/charts/hcp-terraform-operator/crds/app.terraform.io_workspaces.yaml
+++ b/charts/hcp-terraform-operator/crds/app.terraform.io_workspaces.yaml
@@ -734,8 +734,11 @@ spec:
                     type: string
                   fileTriggersEnabled:
                     default: false
-                    description: File triggers allow you to queue runs in Terraform
-                      Cloud when files in your VCS repository change.
+                    description: |-
+                      File triggers allow you to queue runs in HCP Terraform when files in your VCS repository change.
+                      Default: `false`.
+                      More informarion:
+                       - https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings/vcs#automatic-run-triggering
                     type: boolean
                   oAuthTokenID:
                     description: |-
@@ -759,15 +762,21 @@ spec:
                         - https://developer.hashicorp.com/terraform/cloud-docs/run/remote-operations#speculative-plans
                     type: boolean
                   triggerPatterns:
-                    description: The list of pattern triggers that will queue runs
-                      in Terraform Cloud when files in your VCS repository change.
+                    description: |-
+                      The list of pattern triggers that will queue runs in HCP Terraform when files in your VCS repository change.
+                      `spec.versionControl.fileTriggersEnabled` must be set to `true`.
+                      More informarion:
+                       - https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings/vcs#automatic-run-triggering
                     items:
                       type: string
                     minItems: 1
                     type: array
                   triggerPrefixes:
-                    description: The list of pattern prefixes that will queue runs
-                      in Terraform Cloud when files in your VCS repository change.
+                    description: |-
+                      The list of pattern prefixes that will queue runs in HCP Terraform when files in your VCS repository change.
+                      `spec.versionControl.fileTriggersEnabled` must be set to `true`.
+                      More informarion:
+                       - https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings/vcs#automatic-run-triggering
                     items:
                       type: string
                     minItems: 1

--- a/config/crd/bases/app.terraform.io_workspaces.yaml
+++ b/config/crd/bases/app.terraform.io_workspaces.yaml
@@ -731,8 +731,11 @@ spec:
                     type: string
                   fileTriggersEnabled:
                     default: false
-                    description: File triggers allow you to queue runs in Terraform
-                      Cloud when files in your VCS repository change.
+                    description: |-
+                      File triggers allow you to queue runs in HCP Terraform when files in your VCS repository change.
+                      Default: `false`.
+                      More informarion:
+                       - https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings/vcs#automatic-run-triggering
                     type: boolean
                   oAuthTokenID:
                     description: |-
@@ -756,15 +759,21 @@ spec:
                         - https://developer.hashicorp.com/terraform/cloud-docs/run/remote-operations#speculative-plans
                     type: boolean
                   triggerPatterns:
-                    description: The list of pattern triggers that will queue runs
-                      in Terraform Cloud when files in your VCS repository change.
+                    description: |-
+                      The list of pattern triggers that will queue runs in HCP Terraform when files in your VCS repository change.
+                      `spec.versionControl.fileTriggersEnabled` must be set to `true`.
+                      More informarion:
+                       - https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings/vcs#automatic-run-triggering
                     items:
                       type: string
                     minItems: 1
                     type: array
                   triggerPrefixes:
-                    description: The list of pattern prefixes that will queue runs
-                      in Terraform Cloud when files in your VCS repository change.
+                    description: |-
+                      The list of pattern prefixes that will queue runs in HCP Terraform when files in your VCS repository change.
+                      `spec.versionControl.fileTriggersEnabled` must be set to `true`.
+                      More informarion:
+                       - https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings/vcs#automatic-run-triggering
                     items:
                       type: string
                     minItems: 1

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -731,9 +731,9 @@ _Appears in:_
 | `repository` _string_ | A reference to your VCS repository in the format `<organization>/<repository>` where `<organization>` and `<repository>` refer to the organization and repository in your VCS provider. |
 | `branch` _string_ | The repository branch that Run will execute from. This defaults to the repository's default branch (e.g. main). |
 | `speculativePlans` _boolean_ | Whether this workspace allows automatic speculative plans on PR.<br />Default: `true`.<br />More information:<br />  - https://developer.hashicorp.com/terraform/cloud-docs/run/ui#speculative-plans-on-pull-requests<br />  - https://developer.hashicorp.com/terraform/cloud-docs/run/remote-operations#speculative-plans |
-| `fileTriggersEnabled` _boolean_ | File triggers allow you to queue runs in Terraform Cloud when files in your VCS repository change. |
-| `triggerPatterns` _string array_ | The list of pattern triggers that will queue runs in Terraform Cloud when files in your VCS repository change. |
-| `triggerPrefixes` _string array_ | The list of pattern prefixes that will queue runs in Terraform Cloud when files in your VCS repository change. |
+| `fileTriggersEnabled` _boolean_ | File triggers allow you to queue runs in HCP Terraform when files in your VCS repository change.<br />Default: `false`.<br />More informarion:<br /> - https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings/vcs#automatic-run-triggering |
+| `triggerPatterns` _string array_ | The list of pattern triggers that will queue runs in HCP Terraform when files in your VCS repository change.<br />`spec.versionControl.fileTriggersEnabled` must be set to `true`.<br />More informarion:<br /> - https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings/vcs#automatic-run-triggering |
+| `triggerPrefixes` _string array_ | The list of pattern prefixes that will queue runs in HCP Terraform when files in your VCS repository change.<br />`spec.versionControl.fileTriggersEnabled` must be set to `true`.<br />More informarion:<br /> - https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings/vcs#automatic-run-triggering |
 
 
 #### Workspace


### PR DESCRIPTION
### Description

This PR fixes the `spec.versionControl` validation in the Workspace controller.

#### Tests

- [![E2E on HCP Terraform Operator](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/end-to-end-tfc.yaml/badge.svg?branch=fix-validators&event=workflow_dispatch)](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/end-to-end-tfc.yaml?query=branch:fix-validators)
- [![E2E on HCP Terraform Operator [Helm]](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/helm-end-to-end-tfc.yaml/badge.svg?branch=fix-validators&event=workflow_dispatch)](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/helm-end-to-end-tfc.yaml?query=branch:fix-validators)
- [![E2E on Terraform Enterprise](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/end-to-end-tfe.yaml/badge.svg?branch=fix-validators&event=workflow_dispatch)](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/end-to-end-tfe.yaml?query=branch:fix-validators)
- [![E2E on Terraform Enterprise [Helm]](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/helm-end-to-end-tfe.yaml/badge.svg?branch=fix-validators&event=workflow_dispatch)](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/helm-end-to-end-tfe.yaml?query=branch:fix-validators)

### Usage Example

N/A.

### References

N/A.

### Community Note

* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
