### PR TITLE
🐛 Fix an issue with agent scaling during the first run

### DIFF
--- a/.changes/unreleased/BUG FIXES-580-20250321-154528.yaml
+++ b/.changes/unreleased/BUG FIXES-580-20250321-154528.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: '`AgentPool`: Fix an issue where, in some circumstances, a newly created CR with the autoscaling feature enabled does not update its status while handling runs.'
+time: 2025-03-21T15:45:28.002276+01:00
+custom:
+    PR: "580"

--- a/internal/controller/agentpool_controller_autoscaling.go
+++ b/internal/controller/agentpool_controller_autoscaling.go
@@ -230,5 +230,12 @@ func (r *AgentPoolReconciler) reconcileAgentAutoscaling(ctx context.Context, ap 
 			},
 		}
 	}
+
+	if ap.instance.Status.AgentDeploymentAutoscalingStatus == nil {
+		ap.instance.Status.AgentDeploymentAutoscalingStatus = &appv1alpha2.AgentDeploymentAutoscalingStatus{
+			DesiredReplicas: &desiredReplicas,
+		}
+	}
+
 	return nil
 }

--- a/internal/controller/agentpool_controller_autoscaling_test.go
+++ b/internal/controller/agentpool_controller_autoscaling_test.go
@@ -4,45 +4,130 @@
 package controller
 
 import (
+	"fmt"
+	"time"
+
+	tfc "github.com/hashicorp/go-tfe"
+	appv1alpha2 "github.com/hashicorp/hcp-terraform-operator/api/v1alpha2"
+	"github.com/hashicorp/hcp-terraform-operator/internal/pointer"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var _ = Describe("Helpers", Label("Unit"), func() {
-	Context("Match wildcard name", func() {
-		// True
-		It("match prefix", func() {
-			result := matchWildcardName("*-terraform-workspace", "hcp-terraform-workspace")
-			Expect(result).To(BeTrue())
-		})
-		It("match suffix", func() {
-			result := matchWildcardName("hcp-terraform-*", "hcp-terraform-workspace")
-			Expect(result).To(BeTrue())
-		})
-		It("match prefix and suffix", func() {
-			result := matchWildcardName("*-terraform-*", "hcp-terraform-workspace")
-			Expect(result).To(BeTrue())
-		})
-		It("match no prefix and no suffix", func() {
-			result := matchWildcardName("hcp-terraform-workspace", "hcp-terraform-workspace")
-			Expect(result).To(BeTrue())
-		})
-		// False
-		It("does not match prefix", func() {
-			result := matchWildcardName("*-terraform-workspace", "hcp-tf-workspace")
-			Expect(result).To(BeFalse())
-		})
-		It("does not match suffix", func() {
-			result := matchWildcardName("hcp-terraform-*", "hashicorp-tf-workspace")
-			Expect(result).To(BeFalse())
-		})
-		It("does not match prefix and suffix", func() {
-			result := matchWildcardName("*-terraform-*", "hcp-tf-workspace")
-			Expect(result).To(BeFalse())
-		})
-		It("does not match no prefix and no suffix", func() {
-			result := matchWildcardName("hcp-terraform-workspace", "hcp-tf-workspace")
-			Expect(result).To(BeFalse())
+var _ = Describe("Agent Pool controller", Ordered, func() {
+	var (
+		instance       *appv1alpha2.AgentPool
+		namespacedName = newNamespacedName()
+		agentPool      = fmt.Sprintf("kubernetes-operator-agent-pool-%v", randomNumber())
+		workspace      = fmt.Sprintf("kubernetes-operator-%v", randomNumber())
+	)
+
+	BeforeAll(func() {
+		// Set default Eventually timers
+		SetDefaultEventuallyTimeout(syncPeriod * 4)
+		SetDefaultEventuallyPollingInterval(2 * time.Second)
+	})
+
+	BeforeEach(func() {
+		// Create a new module object for each test
+		instance = &appv1alpha2.AgentPool{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "app.terraform.io/v1alpha2",
+				Kind:       "AgentPool",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              namespacedName.Name,
+				Namespace:         namespacedName.Namespace,
+				DeletionTimestamp: nil,
+				Finalizers:        []string{},
+			},
+			Spec: appv1alpha2.AgentPoolSpec{
+				Name:         agentPool,
+				Organization: organization,
+				Token: appv1alpha2.Token{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: secretNamespacedName.Name,
+						},
+						Key: secretKey,
+					},
+				},
+				AgentTokens: []*appv1alpha2.AgentToken{
+					{Name: "token"},
+				},
+				AgentDeployment: &appv1alpha2.AgentDeployment{
+					Replicas: pointer.PointerOf(int32(0)),
+				},
+				AgentDeploymentAutoscaling: &appv1alpha2.AgentDeploymentAutoscaling{
+					MinReplicas:           pointer.PointerOf(int32(0)),
+					MaxReplicas:           pointer.PointerOf(int32(1)),
+					CooldownPeriodSeconds: pointer.PointerOf(int32(5)),
+				},
+			},
+			Status: appv1alpha2.AgentPoolStatus{},
+		}
+	})
+
+	AfterEach(func() {
+		Expect(tfClient.Workspaces.Delete(ctx, organization, workspace)).To(Succeed())
+		Expect(k8sClient.Delete(ctx, instance)).To(Succeed())
+	})
+
+	Context("Autoscaling", func() {
+		It("fix: can update the status property on the first run", func() {
+			// Create a new Workspace
+			ws, err := tfClient.Workspaces.Create(ctx, organization, tfc.WorkspaceCreateOptions{
+				Name:      &workspace,
+				AutoApply: tfc.Bool(true),
+			})
+			Expect(err).Should(Succeed())
+			Expect(ws).ShouldNot(BeNil())
+			// Create a new Run and execute it
+			_ = createAndUploadConfigurationVersion(ws.ID, "hoi")
+			Eventually(func() bool {
+				ws, err = tfClient.Workspaces.ReadByID(ctx, ws.ID)
+				Expect(err).Should(Succeed())
+				Expect(ws).ShouldNot(BeNil())
+				if ws.CurrentRun == nil {
+					return false
+				}
+				run, err := tfClient.Runs.Read(ctx, ws.CurrentRun.ID)
+				Expect(err).Should(Succeed())
+				Expect(run).ShouldNot(BeNil())
+				return run.Status == tfc.RunApplied
+			}).Should(BeTrue())
+			// Create a new Agent Pool
+			Expect(k8sClient.Create(ctx, instance)).Should(Succeed())
+			Eventually(func() bool {
+				Expect(k8sClient.Get(ctx, namespacedName, instance)).Should(Succeed())
+				return instance.Status.AgentPoolID != ""
+			}).Should(BeTrue())
+			// Attrach the Workspace to the Agent pool
+			ws, err = tfClient.Workspaces.UpdateByID(ctx, ws.ID, tfc.WorkspaceUpdateOptions{
+				ExecutionMode: pointer.PointerOf("agent"),
+				AgentPoolID:   &instance.Status.AgentPoolID,
+			})
+			Expect(err).Should(Succeed())
+			Expect(ws).ShouldNot(BeNil())
+			// Trigger a new run
+			run, err := tfClient.Runs.Create(ctx, tfc.RunCreateOptions{
+				PlanOnly: pointer.PointerOf(false),
+				Workspace: &tfc.Workspace{
+					ID: ws.ID,
+				},
+			})
+			Expect(err).Should(Succeed())
+			Expect(run).ShouldNot(BeNil())
+			// Ensure it scales up
+			Eventually(func() bool {
+				Expect(k8sClient.Get(ctx, namespacedName, instance)).Should(Succeed())
+				if instance.Status.AgentDeploymentAutoscalingStatus == nil {
+					return false
+				}
+				return *instance.Status.AgentDeploymentAutoscalingStatus.DesiredReplicas == 1
+			}).Should(BeTrue())
 		})
 	})
 })

--- a/internal/controller/agentpool_controller_deployment.go
+++ b/internal/controller/agentpool_controller_deployment.go
@@ -110,6 +110,8 @@ func (r *AgentPoolReconciler) updateDeployment(ctx context.Context, ap *agentPoo
 		nd.Spec.Replicas = d.Spec.Replicas
 	}
 
+	// TODO:
+	// - Add logic to update the deployment only when it has changed
 	uerr := r.Client.Update(ctx, nd, &client.UpdateOptions{FieldManager: "hcp-terraform-operator"})
 	if uerr != nil {
 		ap.log.Error(uerr, "Reconcile Agent Deployment", "msg", "Failed to update agent deployment")

--- a/internal/controller/agentpool_controller_deployment.go
+++ b/internal/controller/agentpool_controller_deployment.go
@@ -97,15 +97,8 @@ func (r *AgentPoolReconciler) updateDeployment(ctx context.Context, ap *agentPoo
 		nd.Spec.Replicas = a.DesiredReplicas
 	}
 
-	// RARE CASE.
-	// The return value from the agentPoolDeployment() function can set spec.replicas to nil when autoscaling is enabled.
-	// If the status has not yet been updated with the desired replica count, the value will remain nil.
-	// In this case, the Update() method below will default replicas to 1.
-	// If a new agent pool has just been created and there is a pending run, this could overwrite the current replica value,
-	// leading to unnecessary pod terminations or creations.
-	// In this scenario, the status will never be updated.
-	// Since the updateDeployment() method is only called when a corresponding deployment exists, we inherit its value
-	// when spec.replicas is nil.
+	// When spec.replicas is set to nil, the Update() method below defaults it to 1 (one),
+	// which might cause unexpected consequences. Preserve the current value in this case.
 	if nd.Spec.Replicas == nil {
 		nd.Spec.Replicas = d.Spec.Replicas
 	}

--- a/internal/controller/helpers_test.go
+++ b/internal/controller/helpers_test.go
@@ -162,4 +162,41 @@ var _ = Describe("Helpers", Label("Unit"), func() {
 			Expect(isDeletionCandidate(&o, testFinalizer)).To(BeTrue())
 		})
 	})
+
+	Context("Match wildcard name", func() {
+		// True
+		It("match prefix", func() {
+			result := matchWildcardName("*-terraform-workspace", "hcp-terraform-workspace")
+			Expect(result).To(BeTrue())
+		})
+		It("match suffix", func() {
+			result := matchWildcardName("hcp-terraform-*", "hcp-terraform-workspace")
+			Expect(result).To(BeTrue())
+		})
+		It("match prefix and suffix", func() {
+			result := matchWildcardName("*-terraform-*", "hcp-terraform-workspace")
+			Expect(result).To(BeTrue())
+		})
+		It("match no prefix and no suffix", func() {
+			result := matchWildcardName("hcp-terraform-workspace", "hcp-terraform-workspace")
+			Expect(result).To(BeTrue())
+		})
+		// False
+		It("does not match prefix", func() {
+			result := matchWildcardName("*-terraform-workspace", "hcp-tf-workspace")
+			Expect(result).To(BeFalse())
+		})
+		It("does not match suffix", func() {
+			result := matchWildcardName("hcp-terraform-*", "hashicorp-tf-workspace")
+			Expect(result).To(BeFalse())
+		})
+		It("does not match prefix and suffix", func() {
+			result := matchWildcardName("*-terraform-*", "hcp-tf-workspace")
+			Expect(result).To(BeFalse())
+		})
+		It("does not match no prefix and no suffix", func() {
+			result := matchWildcardName("hcp-terraform-workspace", "hcp-tf-workspace")
+			Expect(result).To(BeFalse())
+		})
+	})
 })

--- a/internal/controller/workspace_controller_deletion_policy_test.go
+++ b/internal/controller/workspace_controller_deletion_policy_test.go
@@ -97,7 +97,7 @@ var _ = Describe("Workspace controller", Ordered, func() {
 			createWorkspace(instance)
 			workspaceID := instance.Status.WorkspaceID
 
-			cv := createAndUploadConfigurationVersion(instance, "hoi")
+			cv := createAndUploadConfigurationVersion(instance.Status.WorkspaceID, "hoi")
 			Eventually(func() bool {
 				listOpts := tfc.ListOptions{
 					PageNumber: 1,
@@ -144,7 +144,7 @@ var _ = Describe("Workspace controller", Ordered, func() {
 			createWorkspace(instance)
 			workspaceID := instance.Status.WorkspaceID
 
-			cv := createAndUploadConfigurationVersion(instance, "hoi")
+			cv := createAndUploadConfigurationVersion(instance.Status.WorkspaceID, "hoi")
 			Eventually(func() bool {
 				listOpts := tfc.ListOptions{
 					PageNumber: 1,

--- a/internal/controller/workspace_controller_outputs_test.go
+++ b/internal/controller/workspace_controller_outputs_test.go
@@ -76,7 +76,7 @@ var _ = Describe("Workspace controller", Ordered, func() {
 			createWorkspace(instance)
 
 			outputValue := "hoi"
-			cv := createAndUploadConfigurationVersion(instance, outputValue)
+			cv := createAndUploadConfigurationVersion(instance.Status.WorkspaceID, outputValue)
 
 			By("Validating configuration version and workspace run")
 			Eventually(func() bool {
@@ -132,7 +132,7 @@ var _ = Describe("Workspace controller", Ordered, func() {
 	})
 })
 
-func createAndUploadConfigurationVersion(instance *appv1alpha2.Workspace, outputValue string) *tfc.ConfigurationVersion {
+func createAndUploadConfigurationVersion(wID string, outputValue string) *tfc.ConfigurationVersion {
 	GinkgoHelper()
 	// Create a temporary dir in the current one
 	cd, err := os.Getwd()
@@ -158,7 +158,7 @@ func createAndUploadConfigurationVersion(instance *appv1alpha2.Workspace, output
 	_, err = f.WriteString(tf)
 	Expect(err).Should(Succeed())
 
-	cv, err := tfClient.ConfigurationVersions.Create(ctx, instance.Status.WorkspaceID, tfc.ConfigurationVersionCreateOptions{
+	cv, err := tfClient.ConfigurationVersions.Create(ctx, wID, tfc.ConfigurationVersionCreateOptions{
 		AutoQueueRuns: tfc.Bool(true),
 		Speculative:   tfc.Bool(false),
 	})

--- a/internal/controller/workspace_controller_runs_test.go
+++ b/internal/controller/workspace_controller_runs_test.go
@@ -72,7 +72,7 @@ var _ = Describe("Workspace controller", Ordered, func() {
 			namespacedName := getNamespacedName(instance)
 			// Create a new Kubernetes workspace object and wait until the controller finishes the reconciliation
 			createWorkspace(instance)
-			createAndUploadConfigurationVersion(instance, "hoi")
+			createAndUploadConfigurationVersion(instance.Status.WorkspaceID, "hoi")
 			Eventually(func() bool {
 				Expect(k8sClient.Get(ctx, namespacedName, instance)).Should(Succeed())
 				if instance.Status.Run == nil {
@@ -86,7 +86,7 @@ var _ = Describe("Workspace controller", Ordered, func() {
 			// Create a new Kubernetes workspace object and wait until the controller finishes the reconciliation
 			createWorkspace(instance)
 
-			createAndUploadConfigurationVersion(instance, "hoi")
+			createAndUploadConfigurationVersion(instance.Status.WorkspaceID, "hoi")
 			Eventually(func() bool {
 				Expect(k8sClient.Get(ctx, namespacedName, instance)).Should(Succeed())
 				if instance.Status.Run == nil {


### PR DESCRIPTION
### Description

**_[Agent Pool]_** A newly created CR with `minReplicas` set to 0 results in a deployment with one replica, even when there are no pending runs. The deployment will scale down to 0 during the next reconciliation. If there is a pending run at the time of CR creation, the provisioned deployment replica will pick up this run. However, the CR status will remain unchanged until the next scaling event, which, in some cases, may lead to a prolonged period without a status update.

This PR fixes the behavior described above.

#### Tests

- [![E2E on HCP Terraform Operator](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/end-to-end-tfc.yaml/badge.svg?branch=fix-agent-deployment-issue&event=workflow_dispatch)](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/end-to-end-tfc.yaml?query=branch:fix-agent-deployment-issue)
- [![E2E on HCP Terraform Operator [Helm]](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/helm-end-to-end-tfc.yaml/badge.svg?branch=fix-agent-deployment-issue&event=workflow_dispatch)](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/helm-end-to-end-tfc.yaml?query=branch:fix-agent-deployment-issue)

### Usage Example

N/A.

### References

N/A.

### Community Note

* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
