### PR TITLE
🌱 Bump ubi-micro image from 9.4-15 to 9.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,7 +90,7 @@ ENTRYPOINT ["/bin/sh", "-c", "/$BIN_NAME"]
 
 # Red Hat UBI release image
 # -----------------------------------
-FROM registry.access.redhat.com/ubi9/ubi-micro:9.4-15 AS release-ubi
+FROM registry.access.redhat.com/ubi9/ubi-micro:9.5 AS release-ubi
 
 ARG BIN_NAME
 ARG PRODUCT_VERSION


### PR DESCRIPTION
### Description

Bump `ubi-micro` image from 9.4-15 to 9.5.

### Usage Example

N/A.

### References

N/A.

### Community Note

* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
