### PR TITLE
🌱 Bump kube-rbac-proxy from 0.19.0 to 0.19.1

### DIFF
--- a/.changes/unreleased/DEPENDENCIES-599-20250429-132517.yaml
+++ b/.changes/unreleased/DEPENDENCIES-599-20250429-132517.yaml
@@ -1,0 +1,5 @@
+kind: DEPENDENCIES
+body: Bump `kube-rbac-proxy` from 0.19.0 to 0.19.1.
+time: 2025-04-29T13:25:17.631867+02:00
+custom:
+    PR: "599"

--- a/charts/hcp-terraform-operator/README.md
+++ b/charts/hcp-terraform-operator/README.md
@@ -196,7 +196,7 @@ For a more detailed explanation, please refer to the [FAQ](../../docs/faq.md#gen
 | imagePullSecrets | list | `[]` | Reference to one or more secrets essential for pulling container images. |
 | kubeRbacProxy.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
 | kubeRbacProxy.image.repository | string | `"quay.io/brancz/kube-rbac-proxy"` | Image repository. |
-| kubeRbacProxy.image.tag | string | `"v0.19.0"` | Image tag. |
+| kubeRbacProxy.image.tag | string | `"v0.19.1"` | Image tag. |
 | kubeRbacProxy.resources.limits.cpu | string | `"500m"` | Limits as a maximum amount of CPU to be used by a container. |
 | kubeRbacProxy.resources.limits.memory | string | `"128Mi"` | Limits as a maximum amount of memory to be used by a container. |
 | kubeRbacProxy.resources.requests.cpu | string | `"50m"` | Guaranteed minimum amount of CPU to be used by a container. |

--- a/charts/hcp-terraform-operator/values.yaml
+++ b/charts/hcp-terraform-operator/values.yaml
@@ -90,7 +90,7 @@ kubeRbacProxy:
     # -- Image pull policy.
     pullPolicy: IfNotPresent
     # -- Image tag.
-    tag: v0.19.0
+    tag: v0.19.1
 
   # -- Container security context. More information in [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
   securityContext:


### PR DESCRIPTION
### Description

Bump kube-rbac-proxy from 0.19.0 to 0.19.1.

### Usage Example

N/A.

### References

N/A.

### Community Note

* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
