### PR TITLE
🐛 Change UBI Docker image from micro to minimal

### DIFF
--- a/.changes/unreleased/BUG FIXES-600-20250429-133405.yaml
+++ b/.changes/unreleased/BUG FIXES-600-20250429-133405.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Fixed an issue where the operator could not connect to the HCP Terraform / TFE instance when using the UBI-based image due to a TLS validation error. The previous workaround required setting the `TFC_TLS_SKIP_VERIFY` environment variable to `true` in the Deployment.
+time: 2025-04-29T13:34:05.597842+02:00
+custom:
+    PR: "600"

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,7 +90,7 @@ ENTRYPOINT ["/bin/sh", "-c", "/$BIN_NAME"]
 
 # Red Hat UBI release image
 # -----------------------------------
-FROM registry.access.redhat.com/ubi9/ubi-micro:9.5 AS release-ubi
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5 AS release-ubi
 
 ARG BIN_NAME
 ARG PRODUCT_VERSION


### PR DESCRIPTION
### Description

Change UBI Docker image from `micro` to `minimal`. The `micro` version does not have any built-in trust TLS chains and thus causes TLS certificate validation issues when it tries to connect to the HCP Terraform/TFE instance.

### Usage Example

N/A.

### References

N/A.

### Community Note

* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
