### PR TITLE
🚀 Add the ability to configure environment variables in the deployment

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-601-20250429-135741.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-601-20250429-135741.yaml
@@ -1,5 +1,5 @@
 kind: ENHANCEMENTS
-body: '`Helm Chart``: Add the ability to configure environment variables for the Operator Deployment via `operator.env`.'
+body: '`Helm Chart`: Add the ability to configure environment variables for the Operator Deployment via `operator.env`.'
 time: 2025-04-29T13:57:41.925639+02:00
 custom:
     PR: "601"

--- a/.changes/unreleased/ENHANCEMENTS-601-20250429-135741.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-601-20250429-135741.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: '`Helm Chart``: Add the ability to configure environment variables for the Operator Deployment via `operator.env`.'
+time: 2025-04-29T13:57:41.925639+02:00
+custom:
+    PR: "601"

--- a/charts/hcp-terraform-operator/README.md
+++ b/charts/hcp-terraform-operator/README.md
@@ -203,6 +203,7 @@ For a more detailed explanation, please refer to the [FAQ](../../docs/faq.md#gen
 | kubeRbacProxy.resources.requests.memory | string | `"64Mi"` | Guaranteed minimum amount of memory to be used by a container. |
 | kubeRbacProxy.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"seccompProfile":{"type":"RuntimeDefault"}}` | Container security context. More information in [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/). |
 | operator.affinity | object | `{}` | Kubernetes Affinity. More information: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity |
+| operator.env | object | `{}` | Environment variables. |
 | operator.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
 | operator.image.repository | string | `"hashicorp/hcp-terraform-operator"` | Image repository. |
 | operator.image.tag | string | `""` | Image tag. Defaults to `.Chart.AppVersion`. |

--- a/charts/hcp-terraform-operator/templates/deployment.yaml
+++ b/charts/hcp-terraform-operator/templates/deployment.yaml
@@ -49,6 +49,11 @@ spec:
           - --namespace={{ . }}
           {{- end }}
           {{- $envVars := dict }}
+          {{- if .Values.operator.env }}
+            {{- range $key, $value := .Values.operator.env }}
+              {{- $_ := set $envVars $key $value }}
+            {{- end }}
+          {{- end }}
           {{- if .Values.operator.tfeAddress }}
             {{- $_ := set $envVars "TFE_ADDRESS" .Values.operator.tfeAddress }}
           {{- end }}
@@ -60,7 +65,7 @@ spec:
             {{- range $ek, $ev := $envVars }}
             - name: {{ $ek }}
               value: "{{ $ev -}}"
-            {{ end }}
+            {{- end }}
           {{- end }}
           command:
           - /manager

--- a/charts/hcp-terraform-operator/values.yaml
+++ b/charts/hcp-terraform-operator/values.yaml
@@ -37,6 +37,11 @@ operator:
       cpu: 50m
       # -- Guaranteed minimum amount of memory to be used by a container.
       memory: 64Mi
+  # Usage example:
+  # env:
+  #   HTTP_PROXY: http://proxy:3128
+  # -- Environment variables.
+  env: {}
 
   # -- Container security context. More information in [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
   securityContext:

--- a/charts/test/unit/deployment_test.go
+++ b/charts/test/unit/deployment_test.go
@@ -474,6 +474,25 @@ func TestDeploymentOperatorSkipTLSVerify(t *testing.T) {
 	assert.Equal(t, dd, deployment)
 }
 
+func TestDeploymentOperatorEnv(t *testing.T) {
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"operator.env.HTTP_PROXY": "http://proxy:3128",
+		},
+		Version: helmChartVersion,
+	}
+	deployment := renderDeploymentManifest(t, options)
+	dd := defaultDeployment()
+	dd.Spec.Template.Spec.Containers[0].Env = []corev1.EnvVar{
+		{
+			Name:  "HTTP_PROXY",
+			Value: "http://proxy:3128",
+		},
+	}
+
+	assert.Equal(t, dd, deployment)
+}
+
 func TestDeploymentKubeRbacProxyImage(t *testing.T) {
 	options := &helm.Options{
 		SetValues: map[string]string{


### PR DESCRIPTION
### Description

Add the ability to configure environment variables in the deployment.

### Usage Example

```console
$ helm upgrade this hashicorp/hcp-terraform-operator --namespace default \
    --wait --version 2.9.1 \
    --install \
    --set operator.env.HTTP_PROXY="http://proxy:3128"
```

### References

Fix: https://github.com/hashicorp/hcp-terraform-operator/issues/547

### Community Note

* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
