### PR TITLE
🐛 Fix the early agent termination issue

### DIFF
--- a/.changes/unreleased/BUG FIXES-610-20250527-092719.yaml
+++ b/.changes/unreleased/BUG FIXES-610-20250527-092719.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Fix an issue where the agent can be terminated while it still has an active run during the post-plan or post-apply stage, such as, but not limited to, Sentinel policy evaluation.
+time: 2025-05-27T09:27:19.677453+02:00
+custom:
+    PR: "610"

--- a/internal/controller/agentpool_controller_autoscaling.go
+++ b/internal/controller/agentpool_controller_autoscaling.go
@@ -18,15 +18,6 @@ import (
 	appv1alpha2 "github.com/hashicorp/hcp-terraform-operator/api/v1alpha2"
 )
 
-var (
-	runStatuses = strings.Join([]string{
-		string(tfc.RunPlanQueued),
-		string(tfc.RunApplyQueued),
-		string(tfc.RunApplying),
-		string(tfc.RunPlanning),
-	}, ",")
-)
-
 // matchWildcardName checks if a given string matches a specified wildcard pattern.
 // The wildcard pattern can contain '*' at the beginning and/or end to match any sequence of characters.
 // If the pattern contains '*' at both ends, the function checks if the substring exists within the string.
@@ -66,7 +57,7 @@ func pendingWorkspaceRuns(ctx context.Context, ap *agentPoolInstance) (int32, er
 	runs := map[string]struct{}{}
 	listOpts := &tfc.RunListForOrganizationOptions{
 		AgentPoolNames: ap.instance.Spec.Name,
-		Status:         runStatuses,
+		StatusGroup:    "non_final",
 		ListOptions: tfc.ListOptions{
 			PageSize:   maxPageSize,
 			PageNumber: 1,
@@ -97,7 +88,12 @@ func computeRequiredAgents(ctx context.Context, ap *agentPoolInstance) (int32, e
 	workspaceIDs := map[string]struct{}{}
 
 	listOpts := &tfc.WorkspaceListOptions{
-		CurrentRunStatus: runStatuses,
+		CurrentRunStatus: strings.Join([]string{
+			string(tfc.RunPlanQueued),
+			string(tfc.RunApplyQueued),
+			string(tfc.RunApplying),
+			string(tfc.RunPlanning),
+		}, ","),
 		ListOptions: tfc.ListOptions{
 			PageSize:   maxPageSize,
 			PageNumber: 1,


### PR DESCRIPTION
 ## Rollback Plan

Switch to the previous version of the operator v2.9.1.

 ## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

No.

### Description

This PR fixes an issue where the scaled agent is terminated(due to scale-down event) while a run is still active. This can happen during post-apply or post-plan stages, such as Sentinel policy evaluation and others.

#### Tests

- [![E2E on HCP Terraform Operator](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/end-to-end-tfc.yaml/badge.svg?branch=fix-agent-scaling-status-filtering&event=workflow_dispatch)](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/end-to-end-tfc.yaml?query=branch:fix-agent-scaling-status-filtering)
- [![E2E on HCP Terraform Operator [Helm]](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/helm-end-to-end-tfc.yaml/badge.svg?branch=fix-agent-scaling-status-filtering&event=workflow_dispatch)](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/helm-end-to-end-tfc.yaml?query=branch:fix-agent-scaling-status-filtering)

### Usage Example

N/A.

### References

N/A.

### Community Note

* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
