### PR TITLE
🐛 Adjust agent scaling algorithm to not include waiting for user interaction statuses

### DIFF
--- a/.changes/unreleased/BUG FIXES-618-20250806-133210.yaml
+++ b/.changes/unreleased/BUG FIXES-618-20250806-133210.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: '`AgentPool`:Adjust pendingWorkspaceRuns to not count workspaces with a status requiring user interaction since they can sit in that state for an unknown amount of time.'
+time: 2025-08-06T13:32:10.293471-05:00
+custom:
+    PR: "618"


### PR DESCRIPTION
<!---
Please DO NOT remove any fields from this template. If there is nothing to add, fill in N/A.
Use emojis in the pull request title according to its type:
 - Bug fix: 🐛 Fix ...
 - New feature or enhancement: 🚀 Add ...
 - Documentation: 📖 ...
 - Dependency update: 🌱 Bump ...
For the rest type of the pull requests please use ✨.

Thank you!
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

 ## Rollback Plan

 Switch to a previous version of the operator v.2.9.1.

 ## Changes to Security Controls

 Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

No.

 <!---
Please describe your changes to security controls in detail.
--->

### Description

<!---
This PR fixes an issue in the new scaling algorithm that causes agents to sit around idle when waiting for user interaction, such as confirming a run or overriding a policy.
--->
- Instead of using "non_final" status group which includes runs waiting for user interaction, go back to the previous way of passing in specific statuses.
- Adds in more statuses to cover the issue fixed in GH-610
- Fixes an incorrect log output string

### Usage Example

<!---
Please provide a usage example if you have implemented a new feature.
--->
N/A

### References

<!---
Are there any other GitHub issues (open or closed) or Pull Requests that should be linked here?
For example:
 - Fixes: GH-0000
-->
- Fixes: GH-616

### Community Note
<!--- Please keep this note for the community --->
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
