### PR TITLE
🐛 Sensitive variables not updated on sensitivity change

### DIFF
--- a/.changes/unreleased/BUG FIXES-629-20250804-183959.yaml
+++ b/.changes/unreleased/BUG FIXES-629-20250804-183959.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: '`Workspace`: Fix an issue where sensitive Terraform or Environment variables are not updated when their sensitivity changes.'
+time: 2025-08-04T18:39:59.523146+02:00
+custom:
+    PR: "629"

--- a/internal/controller/workspace_controller_variables.go
+++ b/internal/controller/workspace_controller_variables.go
@@ -73,7 +73,7 @@ func updateWorkspaceVariable(ctx context.Context, w *workspaceInstance, specVari
 		if err := deleteWorkspaceVariable(ctx, w, workspaceVariable); err != nil {
 			return err
 		}
-		if err := createWorkspaceVariable(ctx, w, workspaceVariable); err != nil {
+		if err := createWorkspaceVariable(ctx, w, specVariable); err != nil {
 			return err
 		}
 		w.log.Info("Reconcile Variables", "msg", fmt.Sprintf("successfully updated %s variable %s", specVariable.Category, specVariable.Key))

--- a/internal/controller/workspace_controller_variables_test.go
+++ b/internal/controller/workspace_controller_variables_test.go
@@ -201,7 +201,7 @@ var _ = Describe("Workspace controller", Ordered, func() {
 			// Can make a variable no sensitive
 			instance.Spec.TerraformVariables = []appv1alpha2.Variable{
 				{
-					Name:        "test2",
+					Name:        "test",
 					Description: "test2",
 					Value:       "test2",
 					HCL:         false,
@@ -337,7 +337,7 @@ var _ = Describe("Workspace controller", Ordered, func() {
 			// Can make a variable no sensitive
 			instance.Spec.EnvironmentVariables = []appv1alpha2.Variable{
 				{
-					Name:        "test2",
+					Name:        "test",
 					Description: "test2",
 					Value:       "test2",
 					HCL:         false,


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

No.

### Description

Fix an issue where sensitive Terraform or Environment variables are not updated when their sensitivity changes.

#### Tests

- [![E2E on HCP Terraform Operator](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/end-to-end-tfc.yaml/badge.svg?branch=bug-fix-workspace-vars&event=workflow_dispatch)](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/end-to-end-tfc.yaml?query=branch:bug-fix-workspace-vars)
- [![E2E on HCP Terraform Operator [Helm]](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/helm-end-to-end-tfc.yaml/badge.svg?branch=bug-fix-workspace-vars&event=workflow_dispatch)](https://github.com/hashicorp/hcp-terraform-operator/actions/workflows/helm-end-to-end-tfc.yaml?query=branch:bug-fix-workspace-vars)

### Usage Example

N/A.

### References

Fix: #623.

### Community Note

* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
